### PR TITLE
Improve Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,11 +7,9 @@
 
 
 
-LDFLAGS := -L/usr/local/opt/readline/lib
-CPPFLAGS := -I/usr/local/opt/readline/include
-CFLAGS := '-g -O2'
-
-BREW := $(shell command -v brew 2>/dev/null)
+init: BREW := $(shell command -v brew 2>/dev/null)
+python: CFLAGS := '-I$(brew --prefix readline)/include -g -O2'
+python: LDFLAGS := -L$(brew --prefix readline)/lib
 
 version ?= 3.5.2
 venv ?= 'pottery'


### PR DESCRIPTION
1.  Use the `brew` command to figure out the Readline include and lib paths.

2.  In order to do 1., use target-specific Makefile variables (to avoid putting the cart before the horse).  In other words, we can’t use the `brew` command until we’ve installed Homebrew in the first place.