### PR TITLE
Improve type checking

### DIFF
--- a/pottery/base.py
+++ b/pottery/base.py
@@ -49,7 +49,7 @@ class _Common:
             self.redis.delete(self.key)
 
     def __eq__(self, other):
-        if type(self) == type(other) and \
+        if type(self) is type(other) and \
            self.redis == other.redis and \
            self.key == other.key:
             equals = True

--- a/pottery/monkey.py
+++ b/pottery/monkey.py
@@ -4,6 +4,7 @@
 #   Copyright © 2015-2016, Rajiv Bakulesh Shah, original author.              #
 #   All rights reserved.                                                      #
 #-----------------------------------------------------------------------------#
+'Monkey patches.'
 
 
 
@@ -11,15 +12,23 @@ from redis import Redis
 
 @property
 def _connection(self):
+    'A dictionary representing a Redis connection (host, port, and database).'
     keys = {'host', 'port', 'db'}
     dict_ = {key: self.connection_pool.connection_kwargs[key] for key in keys}
     return dict_
 
 def __eq__(self, other):
+    '''True if two Redis clients are equal.
+
+    The Redis client doesn't have a sane equality test.  So we monkey patch
+    this method on to the Redis client so that two client instances are equal
+    if they're connected to the same Redis host, port, and database.
+    '''
     equals = isinstance(other, Redis) and self._connection == other._connection
     return equals
 
 def __ne__(self, other):
+    'True if two Redis clients are *not* equal.'
     does_not_equal = not self.__eq__(other)
     return does_not_equal
 


### PR DESCRIPTION
Compare two types with `is` (for identity), instead of `==` (for equality).