### PR TITLE
Fix brew upgrade command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@ python:
 
 upgrade:
 	brew update
-	brew upgrade --all
+	brew upgrade
 	brew cleanup
 	pyenv rehash
 	pip3 install --upgrade pip


### PR DESCRIPTION
I typed `$ brew upgrade —all` in Terminal and got this:

```
Warning: We decided to not change the behaviour of `brew upgrade` so
`brew upgrade --all` is equivalent to `brew upgrade` without any other
arguments (so the `--all` is a no-op and can be removed).
```