### PR TITLE
Redis key naming conventions

### DIFF
--- a/pottery/base.py
+++ b/pottery/base.py
@@ -27,7 +27,7 @@ from .exceptions import TooManyTriesError
 class _Common:
     _DEFAULT_REDIS_URL = 'http://localhost:6379/'
     _NUM_TRIES = 3
-    _RANDOM_KEY_PREFIX = 'pottery-'
+    _RANDOM_KEY_PREFIX = 'pottery:'
     _RANDOM_KEY_LENGTH = 16
 
     @staticmethod


### PR DESCRIPTION
From the Redis data types intro (http://redis.io/topics/data-types-intro):

Try to stick with a schema. For instance `object-type:id` is a good idea, as in `user:1000`. Dots or dashes are often used for multi-word fields, as in `comment:1234:reply.to` or `comment:1234:reply-to`.