### PR TITLE
Redis key naming conventions

### DIFF
--- a/pottery/nextid.py
+++ b/pottery/nextid.py
@@ -25,7 +25,8 @@ from redis import Redis
 class NextId:
     'Distributed Redis-powered monotonically increasing ID generator.'
 
-    KEY = 'nextid:current'
+    KEY_PREFIX = 'nextid'
+    KEY = 'current'
     NUM_TRIES = 3
     default_masters = frozenset({Redis()})
 
@@ -35,6 +36,14 @@ class NextId:
         self.masters = masters
         self._set_id_script = self._register_set_id_script()
         self._init_masters()
+
+    @property
+    def key(self):
+        return self._key
+
+    @key.setter
+    def key(self, value):
+        self._key = '{}:{}'.format(self.KEY_PREFIX, value)
 
     def _register_set_id_script(self):
         master = next(iter(self.masters))

--- a/tests/test_nextid.py
+++ b/tests/test_nextid.py
@@ -8,8 +8,6 @@
 
 
 
-from redis import Redis
-
 from pottery import NextId
 from tests.base import TestCase
 
@@ -20,13 +18,11 @@ class NextIdTests(TestCase):
 
     def setUp(self):
         super().setUp()
-        self.redis = Redis()
-        self.redis.delete(NextId.KEY)
+        self.ids = NextId()
+        for master in self.ids.masters:
+            master.set(self.ids.key, 0)
 
     def test_nextid(self):
-        assert not self.redis.exists(NextId.KEY)
-        ids = NextId()
-        assert int(self.redis.get(NextId.KEY)) == 0
         for id_ in range(1, 10):
             with self.subTest(id_=id_):
-                assert next(ids) == id_
+                assert next(self.ids) == id_


### PR DESCRIPTION
From the Redis data types intro (http://redis.io/topics/data-types-intro):

Try to stick with a schema. For instance `object-type:id` is a good idea, as in `user:1000`. Dots or dashes are often used for multi-word fields, as in `comment:1234:reply.to` or `comment:1234:reply-to`.