### PR TITLE
Don't be clever

### DIFF
--- a/pottery/__init__.py
+++ b/pottery/__init__.py
@@ -14,7 +14,7 @@ know how to use Pottery.
 
 
 __title__ = 'pottery'
-__version__ = '0.45'
+__version__ = '0.46'
 __description__, __long_description__ = (
     s.strip() for s in __doc__.split('\n\n', 1)
 )

--- a/pottery/base.py
+++ b/pottery/base.py
@@ -206,7 +206,7 @@ class Iterable(metaclass=abc.ABCMeta):
 
 
 class Primitive(metaclass=abc.ABCMeta):
-    _default_masters = frozenset({Redis()})
+    _default_masters = frozenset({Redis(socket_timeout=1)})
 
     def __init__(self, *, key, masters=_default_masters):
         self.key = key

--- a/pottery/cache.py
+++ b/pottery/cache.py
@@ -31,7 +31,7 @@ def redis_cache(*, key, redis=None, timeout=_DEFAULT_TIMEOUT):
 
     Access the underlying function with f.__wrapped__.
     '''
-    redis = Redis() if redis is None else redis
+    redis = Redis(socket_timeout=1) if redis is None else redis
     cache = RedisDict(redis=redis, key=key)
 
     def decorator(func):

--- a/pottery/nextid.py
+++ b/pottery/nextid.py
@@ -111,9 +111,10 @@ class NextId(Primitive):
 
     @property
     def _current_id(self):
-        current_id, num_masters_gotten = 0, 0
+        futures, current_id, num_masters_gotten = set(), 0, 0
         with concurrent.futures.ThreadPoolExecutor(max_workers=len(self.masters)) as executor:
-            futures = {executor.submit(master.get, self.key) for master in self.masters}
+            for master in self.masters:
+                futures.add(executor.submit(master.get, self.key))
             for future in concurrent.futures.as_completed(futures):
                 with contextlib.suppress(TimeoutError, ConnectionError):
                     current_id = max(current_id, int(future.result()))
@@ -125,9 +126,16 @@ class NextId(Primitive):
 
     @_current_id.setter
     def _current_id(self, value):
-        num_masters_set = 0
+        futures, num_masters_set = set(), 0
         with concurrent.futures.ThreadPoolExecutor(max_workers=len(self.masters)) as executor:
-            futures = {executor.submit(self._set_id_script, keys=(self.key,), args=(value,), client=master) for master in self.masters}
+            for master in self.masters:
+                future = executor.submit(
+                    self._set_id_script,
+                    keys=(self.key,),
+                    args=(value,),
+                    client=master,
+                )
+                futures.add(future)
             for future in concurrent.futures.as_completed(futures):
                 with contextlib.suppress(TimeoutError, ConnectionError):
                     num_masters_set += future.result() == value

--- a/pottery/nextid.py
+++ b/pottery/nextid.py
@@ -46,7 +46,7 @@ class NextId(Primitive):
     Clean up Redis for the doctest:
 
         >>> from redis import Redis
-        >>> Redis().delete('nextid:current') in {0, 1}
+        >>> Redis(socket_timeout=1).delete('nextid:current') in {0, 1}
         True
 
     Usage:


### PR DESCRIPTION
Reverts brainix/pottery#63

This reverts commit 6eba7887c71191c16e5784e0e8b134ea9109164f.

There's no point to bailing out early, as in my tests, all of the
futures complete before we can break out of our for loop.  There's
something about `concurrent.futures.as_completed()` that I don't
understand, so don't be clever.