### PR TITLE
Clean up unit test output

### DIFF
--- a/tests/test_bloom.py
+++ b/tests/test_bloom.py
@@ -26,7 +26,7 @@ class BloomFilterTests(TestCase):
         super().tearDown()
 
     def test_init_without_iterable(self):
-        'Test BloomFilter.__init__() without an iterable for initialization.'
+        'Test BloomFilter.__init__() without an iterable for initialization'
         dilberts = BloomFilter(num_values=100, false_positives=0.01)
         assert dilberts.num_values == 100
         assert dilberts.false_positives == 0.01
@@ -38,7 +38,7 @@ class BloomFilterTests(TestCase):
         assert len(dilberts) == 0
 
     def test_init_with_iterable(self):
-        'Test BloomFilter.__init__() with an iterable for initialization.'
+        'Test BloomFilter.__init__() with an iterable for initialization'
         dilberts = BloomFilter(
             {'rajiv', 'raj'},
             num_values=100,
@@ -58,7 +58,7 @@ class BloomFilterTests(TestCase):
         assert len(dilberts) == 2
 
     def test_size(self):
-        'Test BloomFilter.size().'
+        'Test BloomFilter.size()'
         dilberts = BloomFilter(num_values=100, false_positives=0.1)
         assert dilberts.size() == 480
 
@@ -72,7 +72,7 @@ class BloomFilterTests(TestCase):
         assert dilberts.size() == 9586
 
     def test_num_hashes(self):
-        'Test BloomFilter.num_hashes().'
+        'Test BloomFilter.num_hashes()'
         dilberts = BloomFilter(num_values=100, false_positives=0.1)
         assert dilberts.num_hashes() == 4
 
@@ -86,7 +86,7 @@ class BloomFilterTests(TestCase):
         assert dilberts.num_hashes() == 7
 
     def test_bloom_filter_membership(self):
-        'Test BloomFilter.add() and BloomFilter.__contains__().'
+        'Test BloomFilter.add() and BloomFilter.__contains__()'
         dilberts = BloomFilter(num_values=100, false_positives=0.01)
         assert 'rajiv' not in dilberts
         assert 'raj' not in dilberts
@@ -130,7 +130,7 @@ class BloomFilterTests(TestCase):
         assert 'eric' in dilberts
 
     def test_bloom_filter_len(self):
-        'Test BloomFilter.add() and BloomFilter.__len__().'
+        'Test BloomFilter.add() and BloomFilter.__len__()'
         dilberts = BloomFilter(num_values=100, false_positives=0.01)
         assert len(dilberts) == 0
 
@@ -153,7 +153,7 @@ class BloomFilterTests(TestCase):
         assert len(dilberts) == 4
 
     def test_bloom_filter_update(self):
-        'Test BloomFilter.update() and BloomFilter.__contains__().'
+        'Test BloomFilter.update() and BloomFilter.__contains__()'
         dilberts = BloomFilter(num_values=100, false_positives=0.01)
         assert 'rajiv' not in dilberts
         assert 'raj' not in dilberts
@@ -191,7 +191,7 @@ class BloomFilterTests(TestCase):
         assert 'rhodes' not in dilberts
 
     def test_repr(self):
-        'Test BloomFilter.__repr__().'
+        'Test BloomFilter.__repr__()'
         dilberts = BloomFilter(
             num_values=100,
             false_positives=0.01,
@@ -258,12 +258,12 @@ class RecentlyConsumedTests(TestCase):
             return round(number, ndigits)
 
     def test_zero_false_negatives(self):
-        'Ensure that we produce zero false negatives.'
+        'Ensure that we produce zero false negatives'
         for seen_link in self.seen_links:
             assert seen_link in self.recently_consumed
 
     def test_acceptable_false_positives(self):
-        'Ensure that we produce false positives at an acceptable rate.'
+        'Ensure that we produce false positives at an acceptable rate'
         acceptable, actual = self.recently_consumed.false_positives, 0
 
         for unseen_link in self.unseen_links:

--- a/tests/test_bloom.py
+++ b/tests/test_bloom.py
@@ -57,103 +57,77 @@ class BloomFilterTests(TestCase):
         assert dilberts._num_bits_set() > dilberts.num_hashes() + 1
         assert len(dilberts) == 2
 
-    def test_size(self):
+    def test_size_and_num_hashes(self):
         'Test BloomFilter.size()'
         dilberts = BloomFilter(num_values=100, false_positives=0.1)
         assert dilberts.size() == 480
+        assert dilberts.num_hashes() == 4
 
         dilberts = BloomFilter(num_values=1000, false_positives=0.1)
         assert dilberts.size() == 4793
+        assert dilberts.num_hashes() == 4
 
         dilberts = BloomFilter(num_values=100, false_positives=0.01)
         assert dilberts.size() == 959
+        assert dilberts.num_hashes() == 7
 
         dilberts = BloomFilter(num_values=1000, false_positives=0.01)
         assert dilberts.size() == 9586
-
-    def test_num_hashes(self):
-        'Test BloomFilter.num_hashes()'
-        dilberts = BloomFilter(num_values=100, false_positives=0.1)
-        assert dilberts.num_hashes() == 4
-
-        dilberts = BloomFilter(num_values=1000, false_positives=0.1)
-        assert dilberts.num_hashes() == 4
-
-        dilberts = BloomFilter(num_values=100, false_positives=0.01)
         assert dilberts.num_hashes() == 7
 
-        dilberts = BloomFilter(num_values=1000, false_positives=0.01)
-        assert dilberts.num_hashes() == 7
-
-    def test_bloom_filter_membership(self):
-        'Test BloomFilter.add() and BloomFilter.__contains__()'
+    def test_add(self):
+        'Test BloomFilter add(), __contains__(), and __len__()'
         dilberts = BloomFilter(num_values=100, false_positives=0.01)
         assert 'rajiv' not in dilberts
         assert 'raj' not in dilberts
         assert 'dan' not in dilberts
         assert 'eric' not in dilberts
+        assert len(dilberts) == 0
 
         dilberts.add('rajiv')
         assert 'rajiv' in dilberts
         assert 'raj' not in dilberts
         assert 'dan' not in dilberts
         assert 'eric' not in dilberts
+        assert len(dilberts) == 1
 
         dilberts.add('raj')
         assert 'rajiv' in dilberts
         assert 'raj' in dilberts
         assert 'dan' not in dilberts
         assert 'eric' not in dilberts
+        assert len(dilberts) == 2
 
         dilberts.add('rajiv')
         assert 'rajiv' in dilberts
         assert 'raj' in dilberts
         assert 'dan' not in dilberts
         assert 'eric' not in dilberts
+        assert len(dilberts) == 2
 
         dilberts.add('raj')
         assert 'rajiv' in dilberts
         assert 'raj' in dilberts
         assert 'dan' not in dilberts
         assert 'eric' not in dilberts
+        assert len(dilberts) == 2
 
         dilberts.add('dan')
         assert 'rajiv' in dilberts
         assert 'raj' in dilberts
         assert 'dan' in dilberts
         assert 'eric' not in dilberts
+        assert len(dilberts) == 3
 
         dilberts.add('eric')
         assert 'rajiv' in dilberts
         assert 'raj' in dilberts
         assert 'dan' in dilberts
         assert 'eric' in dilberts
-
-    def test_bloom_filter_len(self):
-        'Test BloomFilter.add() and BloomFilter.__len__()'
-        dilberts = BloomFilter(num_values=100, false_positives=0.01)
-        assert len(dilberts) == 0
-
-        dilberts.add('rajiv')
-        assert len(dilberts) == 1
-
-        dilberts.add('raj')
-        assert len(dilberts) == 2
-
-        dilberts.add('rajiv')
-        assert len(dilberts) == 2
-
-        dilberts.add('raj')
-        assert len(dilberts) == 2
-
-        dilberts.add('dan')
-        assert len(dilberts) == 3
-
-        dilberts.add('eric')
         assert len(dilberts) == 4
 
-    def test_bloom_filter_update(self):
-        'Test BloomFilter.update() and BloomFilter.__contains__()'
+    def test_update(self):
+        'Test BloomFilter update(), __contains__(), and __len__()'
         dilberts = BloomFilter(num_values=100, false_positives=0.01)
         assert 'rajiv' not in dilberts
         assert 'raj' not in dilberts
@@ -162,6 +136,7 @@ class BloomFilterTests(TestCase):
         assert 'jenny' not in dilberts
         assert 'will' not in dilberts
         assert 'rhodes' not in dilberts
+        assert len(dilberts) == 0
 
         dilberts.update({'rajiv', 'raj'}, {'dan', 'eric'})
         assert 'rajiv' in dilberts
@@ -171,6 +146,7 @@ class BloomFilterTests(TestCase):
         assert 'jenny' not in dilberts
         assert 'will' not in dilberts
         assert 'rhodes' not in dilberts
+        assert len(dilberts) == 4
 
         dilberts.update({'jenny', 'will'})
         assert 'rajiv' in dilberts
@@ -180,6 +156,7 @@ class BloomFilterTests(TestCase):
         assert 'jenny' in dilberts
         assert 'will' in dilberts
         assert 'rhodes' not in dilberts
+        assert len(dilberts) == 6
 
         dilberts.update(set())
         assert 'rajiv' in dilberts
@@ -189,6 +166,7 @@ class BloomFilterTests(TestCase):
         assert 'jenny' in dilberts
         assert 'will' in dilberts
         assert 'rhodes' not in dilberts
+        assert len(dilberts) == 6
 
     def test_repr(self):
         'Test BloomFilter.__repr__()'

--- a/tests/test_counter.py
+++ b/tests/test_counter.py
@@ -93,7 +93,7 @@ class CounterTests(TestCase):
         assert c == collections.Counter(a=3, b=0, c=-3, d=-6)
 
     def test_repr(self):
-        'Test RedisCounter.__repr__().'
+        'Test RedisCounter.__repr__()'
         c = RedisCounter(('eggs', 'ham'))
         assert repr(c) in {
             "RedisCounter{'eggs': 1, 'ham': 1}",
@@ -101,7 +101,7 @@ class CounterTests(TestCase):
         }
 
     def test_add(self):
-        'Test RedisCounter.__add__().'
+        'Test RedisCounter.__add__()'
         c = RedisCounter(a=3, b=1)
         d = RedisCounter(a=1, b=2)
         e = c + d
@@ -109,7 +109,7 @@ class CounterTests(TestCase):
         assert e == collections.Counter(a=4, b=3)
 
     def test_sub(self):
-        'Test RedisCounter.__sub__().'
+        'Test RedisCounter.__sub__()'
         c = RedisCounter(a=3, b=1)
         d = RedisCounter(a=1, b=2)
         e = c - d
@@ -117,7 +117,7 @@ class CounterTests(TestCase):
         assert e == collections.Counter(a=2)
 
     def test_or(self):
-        'Test RedisCounter.__or__().'
+        'Test RedisCounter.__or__()'
         c = RedisCounter(a=3, b=1)
         d = RedisCounter(a=1, b=2)
         e = c | d
@@ -125,7 +125,7 @@ class CounterTests(TestCase):
         assert e == collections.Counter(a=3, b=2)
 
     def test_and(self):
-        'Test RedisCounter.__and__().'
+        'Test RedisCounter.__and__()'
         c = RedisCounter(a=3, b=1)
         d = RedisCounter(a=1, b=2)
         e = c & d
@@ -133,19 +133,19 @@ class CounterTests(TestCase):
         assert e == collections.Counter(a=1, b=1)
 
     def test_pos(self):
-        'Test RedisCounter.__pos__().'
+        'Test RedisCounter.__pos__()'
         c = RedisCounter(foo=-2, bar=-1, baz=0, qux=1)
         assert isinstance(+c, collections.Counter)
         assert +c == collections.Counter(qux=1)
 
     def test_neg(self):
-        'Test RedisCounter.__neg__().'
+        'Test RedisCounter.__neg__()'
         c = RedisCounter(foo=-2, bar=-1, baz=0, qux=1)
         assert isinstance(-c, collections.Counter)
         assert -c == collections.Counter(foo=2, bar=1)
 
     def test_in_place_add_with_empty_counter(self):
-        'Test RedisCounter.__iadd__() with an empty counter.'
+        'Test RedisCounter.__iadd__() with an empty counter'
         c = RedisCounter(a=1, b=2)
         d = RedisCounter()
         c += d
@@ -153,7 +153,7 @@ class CounterTests(TestCase):
         assert c == collections.Counter(a=1, b=2)
 
     def test_in_place_add_with_overlapping_counter(self):
-        'Test RedisCounter.__iadd__() with a counter with overlapping keys.'
+        'Test RedisCounter.__iadd__() with a counter with overlapping keys'
         c = RedisCounter(a=4, b=2, c=0, d=-2)
         d = RedisCounter(a=1, b=2, c=3, d=4)
         c += d
@@ -168,7 +168,7 @@ class CounterTests(TestCase):
         assert c == collections.Counter()
 
     def test_in_place_subtract(self):
-        'Test RedisCounter.__isub__().'
+        'Test RedisCounter.__isub__()'
         c = RedisCounter(a=4, b=2, c=0, d=-2)
         d = RedisCounter(a=1, b=2, c=3, d=4)
         c -= d
@@ -176,7 +176,7 @@ class CounterTests(TestCase):
         assert c == collections.Counter(a=3)
 
     def test_in_place_or_with_two_empty_counters(self):
-        'Test RedisCounter.__ior__() with two empty counters.'
+        'Test RedisCounter.__ior__() with two empty counters'
         c = RedisCounter()
         d = RedisCounter()
         c |= d
@@ -184,7 +184,7 @@ class CounterTests(TestCase):
         assert c == collections.Counter()
 
     def test_in_place_or_with_two_overlapping_counters(self):
-        'Test RedisCounter.__ior__() with two counters with overlapping keys.'
+        'Test RedisCounter.__ior__() with two counters with overlapping keys'
         c = RedisCounter(a=4, b=2, c=0, d=-2)
         d = collections.Counter(a=1, b=2, c=3, d=4)
         c |= d
@@ -192,7 +192,7 @@ class CounterTests(TestCase):
         assert c == collections.Counter(a=4, b=2, c=3, d=4)
 
     def test_in_place_and(self):
-        'Test RedisCounter.__iand__().'
+        'Test RedisCounter.__iand__()'
         c = RedisCounter(a=4, b=2, c=0, d=-2)
         d = RedisCounter(a=1, b=2, c=3, d=4)
         c &= d


### PR DESCRIPTION
The Python `unittest` library uses unit test function docstrings as
output.  But then `unittest` adds a ' ... ok' at the end.  Therefore,
don't terminate unit test function docstrings with punctuation.