### PR TITLE
Install pyenv from GitHub source

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@
 
 init upgrade: formulae := {openssl,readline,xz,redis}
 
-version ?= 3.6.3
+version ?= 3.6.4
 venv ?= venv
 
 

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@
 
 
 
-init upgrade: formulae := {openssl,readline,xz,pyenv,redis}
+init upgrade: formulae := {openssl,readline,xz,redis}
 
 version ?= 3.6.3
 venv ?= venv
@@ -22,7 +22,9 @@ init:
 		ruby -e "$$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
 	brew analytics off
 	brew analytics regenerate-uuid
-	brew install $(formulae)
+	-brew install $(formulae)
+	command -v pyenv >/dev/null 2>&1 || \
+		curl -L https://raw.githubusercontent.com/pyenv/pyenv-installer/master/bin/pyenv-installer | bash
 
 python:
 	CFLAGS="-I$(shell brew --prefix openssl)/include -I$(shell brew --prefix readline)/include -g -O2" \
@@ -39,6 +41,7 @@ upgrade:
 	brew update
 	-brew upgrade $(formulae)
 	brew cleanup
+	pyenv update
 	pyenv rehash
 	source $(venv)/bin/activate && \
 		pip3 install --upgrade pip && \

--- a/pottery/deque.py
+++ b/pottery/deque.py
@@ -97,7 +97,10 @@ class RedisDeque(RedisList, collections.deque):
         return super().pop(0)
 
     def rotate(self, n=1):
-        'Rotate the RedisDeque n steps to the right (default n=1).  If n is negative, rotates left.'
+        '''Rotate the RedisDeque n steps to the right (default n=1).
+
+        If n is negative, rotates left.
+        '''
         if n:
             with self._watch():
                 push_method = 'lpush' if n > 0 else 'rpush'
@@ -117,6 +120,6 @@ class RedisDeque(RedisList, collections.deque):
         values = [self._decode(value) for value in encoded]
         repr = self.__class__.__name__ + '(' + str(values)
         if self.maxlen is not None:
-            repr += ', ' + 'maxlen={}'.format(self.maxlen)
+            repr += ', maxlen={}'.format(self.maxlen)
         repr += ')'
         return repr


### PR DESCRIPTION
Before, we were installing `pyenv` using Homebrew, but it looks like the
formula doesn't get updated often enough.  Instead, install `pyenv`
using `pyenv-installer` which pulls from GitHub source.

To upgrade an existing local development environment:

1. `$ brew uninstall pyenv`
2. `$ rm -rf ~/.pyenv/`
3. `$ make install`
4. `$ make upgrade`

For more info:
https://github.com/pyenv/pyenv-installer#github-way-recommended