### PR TITLE
Upgrade Python to 3.7.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ python:
   - "3.4"
   - "3.5"
   - "3.6"
+  - "3.7-dev"
 services: redis-server
 script:
   - coverage3 run -m unittest discover --start-directory tests --verbose

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@
 
 init upgrade: formulae := {openssl,readline,xz,redis}
 
-version ?= 3.6.5
+version ?= 3.7.0
 venv ?= venv
 
 


### PR DESCRIPTION
Note that Python 3.7 (final) isn't yet available on Travis CI, so we're
running 3.7-dev on CI.