### PR TITLE
Upgrade to redis-py 3.0.1

### DIFF
--- a/pottery/__init__.py
+++ b/pottery/__init__.py
@@ -14,7 +14,7 @@ know how to use Pottery.
 
 
 __title__ = 'pottery'
-__version__ = '0.52'
+__version__ = '0.53'
 __description__, __long_description__ = (
     s.strip() for s in __doc__.split(sep='\n\n', maxsplit=1)
 )

--- a/pottery/list.py
+++ b/pottery/list.py
@@ -99,10 +99,10 @@ class RedisList(Base, collections.abc.MutableSequence):
                     self.redis.lset(self.key, index, encoded_value)
                 indices, num = indices[len(encoded_values):], 0
                 for index in indices:
-                    self.redis.lset(self.key, index, None)
+                    self.redis.lset(self.key, index, 0)
                     num += 1
                 if num:
-                    self.redis.lrem(self.key, None, num=num)
+                    self.redis.lrem(self.key, num, 0)
             else:
                 self.redis.multi()
                 self.redis.lset(self.key, index, self._encode(value))
@@ -123,10 +123,10 @@ class RedisList(Base, collections.abc.MutableSequence):
         indices, num = self._slice_to_indices(index), 0
         self.redis.multi()
         for index in indices:
-            self.redis.lset(self.key, index, None)
+            self.redis.lset(self.key, index, 0)
             num += 1
         if num: # pragma: no cover
-            self.redis.lrem(self.key, None, num=num)
+            self.redis.lrem(self.key, num, 0)
 
     def __len__(self):
         'Return the number of items in a RedisList.  O(1)'
@@ -154,10 +154,10 @@ class RedisList(Base, collections.abc.MutableSequence):
             # http://redis.io/commands/linsert
             pivot = self._encode(self[index])
             self.redis.multi()
-            self.redis.lset(self.key, index, None)
+            self.redis.lset(self.key, index, 0)
             for encoded_value in (encoded_value, pivot):
-                self.redis.linsert(self.key, 'BEFORE', None, encoded_value)
-            self.redis.lrem(self.key, None, num=1)
+                self.redis.linsert(self.key, 'BEFORE', 0, encoded_value)
+            self.redis.lrem(self.key, 1, 0)
         else:
             self.redis.multi()
             self.redis.rpush(self.key, encoded_value)

--- a/pottery/redlock.py
+++ b/pottery/redlock.py
@@ -125,7 +125,7 @@ class Redlock(Primitive):
         self.auto_release_time = auto_release_time
         self.num_extensions = num_extensions
 
-        self._value = None
+        self._value = 0
         self._extension_num = 0
         self._acquired_script = self._register_acquired_script()
         self._extend_script = self._register_extend_script()
@@ -205,7 +205,11 @@ class Redlock(Primitive):
         return self.auto_release_time * self.CLOCK_DRIFT_FACTOR + 2
 
     def _acquire_masters(self):
-        self._value, self._extension_num = random.random(), 0
+        while True:
+            self._value = random.random()
+            if self._value:
+                break
+        self._extension_num = 0
         futures, num_masters_acquired = set(), 0
         with ContextTimer() as timer, \
              concurrent.futures.ThreadPoolExecutor(

--- a/requirements-to-freeze.txt
+++ b/requirements-to-freeze.txt
@@ -7,7 +7,7 @@
 
 
 
-redis
+redis>=3.0.0
 murmurhash3
 
 isort

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,7 +20,7 @@ pyflakes==2.0.0
 Pygments==2.2.0
 pyparsing==2.2.0
 readme-renderer==22.0
-redis==2.10.6
+redis==3.0.1
 requests==2.20.1
 requests-toolbelt==0.8.0
 six==1.10.0

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ setup(
     ],
     keywords=pottery.__keywords__,
     packages=find_packages(exclude=('contrib', 'docs', 'tests*')),
-    install_requires=('redis', 'murmurhash3',),
+    install_requires=('redis>=3.0.0', 'murmurhash3',),
     extras_require={},
     package_data={},
     data_files=tuple(),

--- a/tests/base.py
+++ b/tests/base.py
@@ -24,6 +24,7 @@ class TestCase(unittest.TestCase):
     def tearDown(self):
         tmp_key_pattern = Base._RANDOM_KEY_PREFIX + '*'
         tmp_keys = self.redis.keys(pattern=tmp_key_pattern)
+        tmp_keys = ' '.join(tmp_key.decode('utf-8') for tmp_key in tmp_keys)
         self.redis.delete(tmp_keys)
         super().tearDown()
 

--- a/tests/test_redlock.py
+++ b/tests/test_redlock.py
@@ -177,4 +177,4 @@ class RedlockTests(TestCase):
 
     def test_repr(self):
         assert repr(self.redlock) == \
-            '<Redlock key=redlock:printer value=None timeout=0>'
+            '<Redlock key=redlock:printer value=0 timeout=0>'


### PR DESCRIPTION
`redis-py` 3.0.0 introduced some backwards incompatible changes, so I've
had to pin to at least 3.0.0 and make the recommended changes:

https://github.com/andymccurdy/redis-py/tree/c8936f7c713e333c21dd7a6d5ecfa582bcafb535#upgrading-from-redis-py-2x-to-30