### PR TITLE
Modify Redlock to use 20 byte random values

### DIFF
--- a/pottery/redlock.py
+++ b/pottery/redlock.py
@@ -25,8 +25,8 @@ Lua scripting:
 
 import concurrent.futures
 import contextlib
+import os
 import random
-import secrets
 import time
 
 from redis.exceptions import ConnectionError
@@ -210,7 +210,7 @@ class Redlock(Primitive):
         return self.auto_release_time * self.CLOCK_DRIFT_FACTOR + 2
 
     def _acquire_masters(self):
-        self._value = secrets.token_bytes(nbytes=self.num_random_bytes)
+        self._value = os.urandom(self.num_random_bytes)
         self._extension_num = 0
         futures, num_masters_acquired = set(), 0
         with ContextTimer() as timer, \

--- a/tests/test_redlock.py
+++ b/tests/test_redlock.py
@@ -177,4 +177,4 @@ class RedlockTests(TestCase):
 
     def test_repr(self):
         assert repr(self.redlock) == \
-            '<Redlock key=redlock:printer value=0 timeout=0>'
+            "<Redlock key=redlock:printer value=b'' timeout=0>"


### PR DESCRIPTION
`antirez` recommends using 20 bytes from `/dev/urandom` for Redlock
values (to avoid value conflicts).  Previously, I was using
`random.random()` floats.

Stick to `antirez`'s recommendation.  :-)

https://github.com/antirez/redlock-rb/blob/97be08b307eaad7f9b23db41e8def691ea41a342/redlock.rb#L46-L53