### PR TITLE
Allow bypassing redis_cache() decorator

### DIFF
--- a/pottery/__init__.py
+++ b/pottery/__init__.py
@@ -14,7 +14,7 @@ know how to use Pottery.
 
 
 __title__ = 'pottery'
-__version__ = '0.53'
+__version__ = '0.54'
 __description__, __long_description__ = (
     s.strip() for s in __doc__.split(sep='\n\n', maxsplit=1)
 )


### PR DESCRIPTION
Background:
https://www.reddit.com/r/flask/comments/acpk6v/wrapping_unsupported_database_w_flask_and_redis/ed9ulof/

You can cache an expensive function like so:

    @redis_cache(key='expensive-function')
    def expensive_function():
        return None

You can access the raw underlying function directly with:

    expensive_function.__wrapped__()

And now, you can bypass the cache and force a hard refresh with:

    expensive_function.__bypass__()