### PR TITLE
Implement cache_info() and cache_clear()

### DIFF
--- a/pottery/__init__.py
+++ b/pottery/__init__.py
@@ -14,7 +14,7 @@ know how to use Pottery.
 
 
 __title__ = 'pottery'
-__version__ = '0.54'
+__version__ = '0.55'
 __description__, __long_description__ = (
     s.strip() for s in __doc__.split(sep='\n\n', maxsplit=1)
 )

--- a/pottery/cache.py
+++ b/pottery/cache.py
@@ -50,7 +50,7 @@ def redis_cache(*, redis=None, key=None, timeout=_DEFAULT_TIMEOUT):
     Additionally, this decorator provides the following functions:
 
     f.__wrapped__(*args, **kwargs)
-        Provide access to the original underlying function.  This is useful for
+        Access the original underlying function.  This is useful for
         introspection, for bypassing the cache, or for rewrapping the function
         with a different cache.
 
@@ -62,9 +62,18 @@ def redis_cache(*, redis=None, key=None, timeout=_DEFAULT_TIMEOUT):
     f.cache_info()
         Return a namedtuple showing hits, misses, maxsize, and currsize.  This
         information is helpful for measuring the effectiveness of the cache.
+
         Note that maxsize is always None, meaning that this cache is always
         unbounded.  maxsize is only included for compatibility with
         functools.lru_cache().
+
+        While redis_cache() is thread-safe, also note that hits/misses only
+        instrument your local process - not other processes, even if connected
+        to the same Redis-backed redis_cache() key.  And in some cases,
+        hits/misses may be incorrect in multiprocess/distributed applications.
+
+        That said, currsize is always correct, even if other remote processes
+        modify the same Redis-backed redis_cache() key.
 
     f.cache_clear()
         Clear/invalidate the entire cache (for all args/kwargs previously

--- a/pottery/exceptions.py
+++ b/pottery/exceptions.py
@@ -31,6 +31,9 @@ class KeyExistsError(PotteryError):
 class RandomKeyError(PotteryError, RuntimeError):
     "Can't create a random Redis key; all of our attempts already exist."
 
+    def __init__(self, redis):
+        super().__init__(redis, None)
+
     def __repr__(self):
         return "{}(redis={})".format(self.__class__.__name__, self._redis)
 


### PR DESCRIPTION
This brings our `redis_cache()` API closer to `functools.lru_cache()`
without introducing any backward incompatible changes.  These two
functions also help clean up our test suite and make it more robust and
tell a better story.