### PR TITLE
Upgrade pip to 19.0.1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,7 @@ upgrade:
 	pyenv rehash
 	source $(venv)/bin/activate && \
 		pip3 install --upgrade pip && \
-		pip3 install --requirement requirements-to-freeze.txt --upgrade && \
+		pip3 install --requirement requirements-to-freeze.txt --upgrade --no-cache-dir && \
 		pip3 freeze > requirements.txt
 	git status
 	git diff


### PR DESCRIPTION
This reverts commit 0a539c265d35dbf36416d051549aed9785cf59cf.

Apparently, 19.0.1 fixes the `--no-cache-dir` command-line option.