### PR TITLE
Upgrade redis-py to 3.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Python](https://github.com/vinta/awesome-python#awesome-python-) list!
 First, set up your Redis client: :alien:
 
     >>> from redis import Redis
-    >>> redis = Redis.from_url('http://localhost:6379/')
+    >>> redis = Redis.from_url('redis://localhost:6379/')
 
 That was the hardest part. :grimacing:
 

--- a/pottery/__init__.py
+++ b/pottery/__init__.py
@@ -14,7 +14,7 @@ know how to use Pottery.
 
 
 __title__ = 'pottery'
-__version__ = '0.55'
+__version__ = '0.56'
 __description__, __long_description__ = (
     s.strip() for s in __doc__.split(sep='\n\n', maxsplit=1)
 )

--- a/pottery/base.py
+++ b/pottery/base.py
@@ -27,7 +27,7 @@ from .exceptions import RandomKeyError
 
 
 monkey  # Workaround for Pyflakes.  :-(
-_default_url = os.environ.get('REDIS_URL', 'http://localhost:6379/')
+_default_url = os.environ.get('REDIS_URL', 'redis://localhost:6379/')
 _default_redis = Redis.from_url(_default_url, socket_timeout=1)
 _logger = logging.getLogger('pottery')
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,7 +20,7 @@ pyflakes==2.1.0
 Pygments==2.2.0
 pyparsing==2.2.0
 readme-renderer==22.0
-redis==3.0.1
+redis==3.1.0
 requests==2.21.0
 requests-toolbelt==0.8.0
 six==1.10.0

--- a/tests/test_redis.py
+++ b/tests/test_redis.py
@@ -19,7 +19,7 @@ monkey  # Workaround for Pyflakes.  :-(
 
 
 class RedisTests(TestCase):
-    _REDIS_URL = 'http://localhost:6379/'
+    _REDIS_URL = 'redis://localhost:6379/'
 
     def test_redis_clients_equal_if_same_url(self):
         # The Redis client doesn't have a sane equality test.  So we've monkey


### PR DESCRIPTION
`redis-py` 3.1.0 introduces one backward incompatible change: Connection
URLs must now begin with `redis://`, `rediss://`, or `unix://`.

https://github.com/andymccurdy/redis-py/blob/5a2e26d2b0b554bfcd6875a968bcd8090b7f9b03/CHANGES#L1-L3