### PR TITLE
Gracefully ignore isort import keyerror

### DIFF
--- a/pottery/__init__.py
+++ b/pottery/__init__.py
@@ -14,7 +14,7 @@ know how to use Pottery.
 
 
 __title__ = 'pottery'
-__version__ = '0.57'
+__version__ = '0.58'
 __description__, __long_description__ = (
     s.strip() for s in __doc__.split(sep='\n\n', maxsplit=1)
 )

--- a/pottery/monkey.py
+++ b/pottery/monkey.py
@@ -90,7 +90,14 @@ def _correctly_sorted(self):
     return not self.incorrectly_sorted
 
 import contextlib
-with contextlib.suppress(ImportError):
+
+# XXX: This is a workaround for pip 9.0.2, which is the version that runs on
+# Heroku.  For some reason, the following isort import imports requests, and if
+# we import requests before/without importing pip, we get a KeyError.
+#
+# For more info:
+#   https://github.com/pypa/pip/issues/5079#issuecomment-373927413
+with contextlib.suppress(ImportError, KeyError):
     from isort import SortImports
     SortImports.correctly_sorted = _correctly_sorted
 


### PR DESCRIPTION
This is a workaround for `pip` 9.0.2, which is the version that runs on
Heroku.  For some reason, importing `isort` import imports `requests`,
and if we import `requests` before/without importing `pip`, we get a
`KeyError`.

We only need for this import to succeed locally and on CI (basically,
anywhere where we want to run our test suite), so it's ok for this to
fail on production.

For more info:
  https://github.com/pypa/pip/issues/5079#issuecomment-373927413