### PR TITLE
Delete max_workers argument to ThreadPoolExecutor

### DIFF
--- a/pottery/nextid.py
+++ b/pottery/nextid.py
@@ -86,9 +86,7 @@ class NextId(Primitive):
         return set_id_script
 
     def _init_masters(self):
-        with concurrent.futures.ThreadPoolExecutor(
-            max_workers=len(self.masters),
-        ) as executor:
+        with concurrent.futures.ThreadPoolExecutor() as executor:
             for master in self.masters:
                 executor.submit(master.setnx, self.key, 0)
 
@@ -114,9 +112,7 @@ class NextId(Primitive):
     @property
     def _current_id(self):
         futures, current_id, num_masters_gotten = set(), 0, 0
-        with concurrent.futures.ThreadPoolExecutor(
-            max_workers=len(self.masters),
-        ) as executor:
+        with concurrent.futures.ThreadPoolExecutor() as executor:
             for master in self.masters:
                 futures.add(executor.submit(master.get, self.key))
             for future in concurrent.futures.as_completed(futures):
@@ -131,9 +127,7 @@ class NextId(Primitive):
     @_current_id.setter
     def _current_id(self, value):
         futures, num_masters_set = set(), 0
-        with concurrent.futures.ThreadPoolExecutor(
-            max_workers=len(self.masters),
-        ) as executor:
+        with concurrent.futures.ThreadPoolExecutor() as executor:
             for master in self.masters:
                 future = executor.submit(
                     self._set_id_script,

--- a/pottery/redlock.py
+++ b/pottery/redlock.py
@@ -214,9 +214,7 @@ class Redlock(Primitive):
         self._extension_num = 0
         futures, num_masters_acquired = set(), 0
         with ContextTimer() as timer, \
-             concurrent.futures.ThreadPoolExecutor(
-                max_workers=len(self.masters),
-             ) as executor:
+             concurrent.futures.ThreadPoolExecutor() as executor:
             for master in self.masters:
                 futures.add(executor.submit(self._acquire_master, master))
             for future in concurrent.futures.as_completed(futures):
@@ -317,9 +315,7 @@ class Redlock(Primitive):
         '''
         futures, num_masters_acquired, ttls = set(), 0, []
         with ContextTimer() as timer, \
-             concurrent.futures.ThreadPoolExecutor(
-                max_workers=len(self.masters),
-             ) as executor:
+             concurrent.futures.ThreadPoolExecutor() as executor:
             for master in self.masters:
                 futures.add(executor.submit(self._acquired_master, master))
             for future in concurrent.futures.as_completed(futures):
@@ -359,9 +355,7 @@ class Redlock(Primitive):
             raise TooManyExtensions(self.masters, self.key)
         else:
             futures, num_masters_extended = set(), 0
-            with concurrent.futures.ThreadPoolExecutor(
-                max_workers=len(self.masters),
-            ) as executor:
+            with concurrent.futures.ThreadPoolExecutor() as executor:
                 for master in self.masters:
                     futures.add(executor.submit(self._extend_master, master))
                 for future in concurrent.futures.as_completed(futures):
@@ -388,9 +382,7 @@ class Redlock(Primitive):
             False
         '''
         futures, num_masters_released = set(), 0
-        with concurrent.futures.ThreadPoolExecutor(
-            max_workers=len(self.masters),
-        ) as executor:
+        with concurrent.futures.ThreadPoolExecutor() as executor:
             for master in self.masters:
                 futures.add(executor.submit(self._release_master, master))
             for future in concurrent.futures.as_completed(futures):


### PR DESCRIPTION
This argument was required for Python 3.4, but is optional for Python
3.5 and newer:

https://docs.python.org/3.5/library/concurrent.futures.html#concurrent.futures.ThreadPoolExecutor