### PR TITLE
Upgrade Python to 3.7.4

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@
 
 init upgrade: formulae := {openssl,readline,xz,redis}
 
-version ?= 3.7.3
+version ?= 3.7.4
 venv ?= venv
 
 
@@ -27,7 +27,7 @@ init:
 		curl -L https://raw.githubusercontent.com/pyenv/pyenv-installer/master/bin/pyenv-installer | bash
 
 python:
-	CFLAGS="-I$(shell xcrun --show-sdk-path)/usr/include -I$(shell brew --prefix openssl)/include -I$(shell brew --prefix readline)/include -g -O2" \
+	CFLAGS="-I$(shell brew --prefix openssl)/include -I$(shell brew --prefix readline)/include -g -O2" \
 		LDFLAGS="-L$(shell brew --prefix openssl)/lib -L$(shell brew --prefix readline)/lib" \
 		pyenv install --skip-existing $(version)
 	pyenv rehash


### PR DESCRIPTION
When I just bumped the version number in `Makefile` and tried to `$ make
python`, I got this error:

    ModuleNotFoundError: No module named 'pyexpat'

After some Googling, I found the fix here:
https://github.com/pyenv/pyenv/issues/1066#issuecomment-358491235