### PR TITLE
Remove redundant self.redis assignment in tests

### DIFF
--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -12,7 +12,6 @@ import time
 import unittest
 
 from pottery import redis_cache
-from pottery.base import _default_redis
 from pottery.cache import _DEFAULT_TIMEOUT
 from pottery.cache import CachedOrderedDict
 from pottery.cache import CacheInfo
@@ -25,7 +24,6 @@ class CacheTests(TestCase):
 
     def setUp(self):
         super().setUp()
-        self.redis = _default_redis
         self.expensive_method.cache_clear()
 
     def tearDown(self):
@@ -245,7 +243,6 @@ class CachedOrderedDictTests(TestCase):
 
     def setUp(self):
         super().setUp()
-        self.redis = _default_redis
         self.redis.delete(self._KEY)
 
     def tearDown(self):

--- a/tests/test_redlock.py
+++ b/tests/test_redlock.py
@@ -15,7 +15,6 @@ from pottery import ContextTimer
 from pottery import Redlock
 from pottery import ReleaseUnlockedLock
 from pottery import TooManyExtensions
-from pottery.base import _default_redis
 from tests.base import TestCase
 
 
@@ -25,7 +24,6 @@ class RedlockTests(TestCase):
 
     def setUp(self):
         super().setUp()
-        self.redis = _default_redis
         self.redlock = Redlock(
             masters={self.redis},
             key='printer',


### PR DESCRIPTION
We already assign `self.redis` in the base `TestCase` class's `setUp()`
method.