### PR TITLE
Add __eq__() method on ConnectionPool class

### DIFF
--- a/pottery/monkey.py
+++ b/pottery/monkey.py
@@ -41,6 +41,11 @@ _logger.info('Monkey patched os.listdir() to optionally return absolute paths')
 # The Redis client doesn't have a sane equality test.  So monkey patch equality
 # comparisons on to the Redis client.  We consider two Redis clients to be
 # equal if they're connected to the same host, port, and database.
+#
+# I've submitted this change to redis-py:
+#     https://github.com/andymccurdy/redis-py/pull/1240
+#
+# If it gets merged upstream, then I'll be able to delete this monkey patch.
 
 from redis import ConnectionPool
 from redis import Redis

--- a/tests/test_set.py
+++ b/tests/test_set.py
@@ -7,6 +7,8 @@
 
 
 
+from redis import Redis
+
 from pottery import KeyExistsError
 from pottery import RedisSet
 from tests.base import TestCase
@@ -106,6 +108,13 @@ class SetTests(TestCase):
         b = RedisSet('cde')
         assert not a.isdisjoint(b)
         c = RedisSet('def')
+        assert a.isdisjoint(c)
+
+        other_url = 'redis://127.0.0.1:6379/'
+        other_redis = Redis.from_url(other_url, socket_timeout=1)
+        b = RedisSet('cde', redis=other_redis)
+        assert not a.isdisjoint(b)
+        c = RedisSet('def', redis=other_redis)
         assert a.isdisjoint(c)
 
         d = {'c', 'd', 'e'}


### PR DESCRIPTION
This is a more natural place to compare Redis connections.  Then we can
use `ConnectionPool.__eq__()` to implement `Redis.__eq__()`.  This feels
less hacky.

I've submitted this change to `redis-py`:
https://github.com/andymccurdy/redis-py/pull/1240

If it gets merged upstream, then I'll be able to delete this monkey
patch.