### PR TITLE
Refactor CachedOrderedDict

### DIFF
--- a/pottery/__init__.py
+++ b/pottery/__init__.py
@@ -14,7 +14,7 @@ know how to use Pottery.
 
 
 __title__ = 'pottery'
-__version__ = '0.63'
+__version__ = '0.64'
 __description__, __long_description__ = (
     s.strip() for s in __doc__.split(sep='\n\n', maxsplit=1)
 )

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,6 +17,6 @@ requests==2.22.0
 requests-toolbelt==0.9.1
 six==1.13.0
 tqdm==4.38.0
-twine==3.0.0
+twine==3.1.0
 urllib3==1.25.7
 webencodings==0.5.1

--- a/tests/base.py
+++ b/tests/base.py
@@ -17,15 +17,21 @@ from pottery.base import _default_redis
 
 
 class TestCase(unittest.TestCase):
+    _TEST_KEY_PREFIX = 'pottery-test:'
+
     def setUp(self):
         super().setUp()
         self.redis = _default_redis
 
     def tearDown(self):
-        tmp_key_pattern = Base._RANDOM_KEY_PREFIX + '*'
-        tmp_keys = self.redis.keys(pattern=tmp_key_pattern)
-        tmp_keys = ' '.join(tmp_key.decode('utf-8') for tmp_key in tmp_keys)
-        self.redis.delete(tmp_keys)
+        keys_to_delete = []
+        for prefix in {Base._RANDOM_KEY_PREFIX, self._TEST_KEY_PREFIX}:
+            pattern = prefix + '*'
+            keys = self.redis.keys(pattern=pattern)
+            keys = (key.decode('utf-8') for key in keys)
+            keys_to_delete.extend(keys)
+        if keys_to_delete:
+            self.redis.delete(*keys_to_delete)
         super().tearDown()
 
 

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -18,29 +18,31 @@ from tests.base import TestCase
 class _BaseTestCase(TestCase):
     def setUp(self):
         super().setUp()
-
-        self.redis.delete('pottery:raj')
         self.raj = RedisDict(key='pottery:raj', hobby='music', vegetarian=True)
-
-        self.redis.delete('pottery:nilika')
         self.nilika = RedisDict(
             key='pottery:nilika',
             hobby='music',
             vegetarian=True,
         )
-
-        self.redis.delete('luvh')
         self.luvh = RedisDict(key='luvh', hobby='bullying', vegetarian=False)
 
     def tearDown(self):
-        self.redis.delete('pottery:raj', 'pottery:nilika', 'luvh')
+        self.redis.delete('luvh')
         super().tearDown()
 
 
 
 class CommonTests(_BaseTestCase):
     def test_del(self):
-        with unittest.mock.patch.object(self.luvh.redis, 'delete') as delete:
+        with unittest.mock.patch.object(self.redis, 'delete') as delete:
+            del self.raj
+            delete.assert_called_with('pottery:raj')
+            delete.reset_mock()
+
+            del self.nilika
+            delete.assert_called_with('pottery:nilika')
+            delete.reset_mock()
+
             del self.luvh
             delete.assert_not_called()
 

--- a/tests/test_bloom.py
+++ b/tests/test_bloom.py
@@ -17,13 +17,7 @@ from tests.base import TestCase
 
 
 class BloomFilterTests(TestCase):
-    def setUp(self):
-        super().setUp()
-        self.redis.delete('dilberts')
-
-    def tearDown(self):
-        self.redis.delete('dilberts')
-        super().tearDown()
+    _KEY = '{}dilberts'.format(TestCase._TEST_KEY_PREFIX)
 
     def test_init_without_iterable(self):
         'Test BloomFilter.__init__() without an iterable for initialization'
@@ -173,18 +167,19 @@ class BloomFilterTests(TestCase):
         dilberts = BloomFilter(
             num_values=100,
             false_positives=0.01,
-            key='dilberts',
+            key=self._KEY,
         )
-        assert repr(dilberts) == '<BloomFilter key=dilberts>'
+        assert repr(dilberts) == '<BloomFilter key={}>'.format(self._KEY)
 
 
 
 class RecentlyConsumedTests(TestCase):
     "Simulate reddit's recently consumed problem to test our Bloom filter."
 
+    _KEY = '{}recently-consumed'.format(TestCase._TEST_KEY_PREFIX)
+
     def setUp(self):
         super().setUp()
-        self.redis.delete('recently-consumed')
 
         # Construct a set of links that the user has seen.
         self.seen_links = set()
@@ -205,11 +200,10 @@ class RecentlyConsumedTests(TestCase):
             self.seen_links,
             num_values=1000,
             false_positives=0.001,
-            key='recently-consumed',
+            key=self._KEY,
         )
 
     def tearDown(self):
-        self.recently_consumed.clear()
         super().tearDown()
 
     @staticmethod

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -21,7 +21,7 @@ from tests.base import TestCase
 
 
 class CacheDecoratorTests(TestCase):
-    _KEY = 'expensive-method'
+    _KEY = '{}expensive-method'.format(TestCase._TEST_KEY_PREFIX)
 
     def setUp(self):
         super().setUp()
@@ -240,11 +240,10 @@ class CacheDecoratorTests(TestCase):
 
 
 class CachedOrderedDictTests(TestCase):
-    _KEY = 'cached-ordereddict'
+    _KEY = '{}cached-ordereddict'.format(TestCase._TEST_KEY_PREFIX)
 
     def setUp(self):
         super().setUp()
-        self.redis.delete(self._KEY)
 
         # Populate the cache with three hits:
         with CachedOrderedDict(
@@ -262,10 +261,6 @@ class CachedOrderedDictTests(TestCase):
             key=self._KEY,
             keys=('hit1', 'miss1', 'hit2', 'miss2', 'hit3', 'miss3'),
         )
-
-    def tearDown(self):
-        self.redis.delete(self._KEY)
-        super().tearDown()
 
     def test_setitem(self):
         assert self.cache == collections.OrderedDict((

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -7,6 +7,7 @@
 
 
 
+import collections
 import random
 import time
 import unittest
@@ -19,7 +20,7 @@ from tests.base import TestCase
 
 
 
-class CacheTests(TestCase):
+class CacheDecoratorTests(TestCase):
     _KEY = 'expensive-method'
 
     def setUp(self):
@@ -239,17 +240,12 @@ class CacheTests(TestCase):
 
 
 class CachedOrderedDictTests(TestCase):
-    _KEY = 'cache-ordereddict'
+    _KEY = 'cached-ordereddict'
 
     def setUp(self):
         super().setUp()
         self.redis.delete(self._KEY)
 
-    def tearDown(self):
-        self.redis.delete(self._KEY)
-        super().tearDown()
-
-    def test_cachedorderedict(self):
         # Populate the cache with three hits:
         with CachedOrderedDict(
             redis=self.redis,
@@ -261,19 +257,150 @@ class CachedOrderedDictTests(TestCase):
             cache['hit3'] = 'value3'
 
         # Instantiate the cache again with the three hits and three misses:
-        cache = CachedOrderedDict(
+        self.cache = CachedOrderedDict(
             redis=self.redis,
             key=self._KEY,
             keys=('hit1', 'miss1', 'hit2', 'miss2', 'hit3', 'miss3'),
         )
 
-        # Ensure that the hits are hits, the misses are misses, and the cache
-        # is ordered:
-        assert tuple(cache.items()) == (
+    def tearDown(self):
+        self.redis.delete(self._KEY)
+        super().tearDown()
+
+    def test_setitem(self):
+        assert self.cache == collections.OrderedDict((
             ('hit1', 'value1'),
             ('miss1', CachedOrderedDict._SENTINEL),
             ('hit2', 'value2'),
             ('miss2', CachedOrderedDict._SENTINEL),
             ('hit3', 'value3'),
             ('miss3', CachedOrderedDict._SENTINEL),
-        )
+        ))
+        assert self.cache._cache == {
+            'hit1': 'value1',
+            'hit2': 'value2',
+            'hit3': 'value3',
+        }
+        assert self.cache.misses() == {'miss1', 'miss2', 'miss3'}
+
+        self.cache['hit4'] = 'value4'
+        assert self.cache == collections.OrderedDict((
+            ('hit1', 'value1'),
+            ('miss1', CachedOrderedDict._SENTINEL),
+            ('hit2', 'value2'),
+            ('miss2', CachedOrderedDict._SENTINEL),
+            ('hit3', 'value3'),
+            ('miss3', CachedOrderedDict._SENTINEL),
+            ('hit4', 'value4'),
+        ))
+        assert self.cache._cache == {
+            'hit1': 'value1',
+            'hit2': 'value2',
+            'hit3': 'value3',
+            'hit4': 'value4',
+        }
+        assert self.cache.misses() == {'miss1', 'miss2', 'miss3'}
+
+        self.cache['miss1'] = 'value1'
+        assert self.cache == collections.OrderedDict((
+            ('hit1', 'value1'),
+            ('miss1', 'value1'),
+            ('hit2', 'value2'),
+            ('miss2', CachedOrderedDict._SENTINEL),
+            ('hit3', 'value3'),
+            ('miss3', CachedOrderedDict._SENTINEL),
+            ('hit4', 'value4'),
+        ))
+        assert self.cache._cache == {
+            'hit1': 'value1',
+            'hit2': 'value2',
+            'hit3': 'value3',
+            'hit4': 'value4',
+            'miss1': 'value1',
+        }
+        assert self.cache.misses() == {'miss2', 'miss3'}
+
+    def test_setdefault(self):
+        'Ensure setdefault() sets the key iff the key does not exist.'
+        for default in ('rajiv', 'raj'):
+            with self.subTest(default=default):
+                self.cache.setdefault('first', default=default)
+                assert self.cache == collections.OrderedDict((
+                    ('hit1', 'value1'),
+                    ('miss1', CachedOrderedDict._SENTINEL),
+                    ('hit2', 'value2'),
+                    ('miss2', CachedOrderedDict._SENTINEL),
+                    ('hit3', 'value3'),
+                    ('miss3', CachedOrderedDict._SENTINEL),
+                    ('first', 'rajiv'),
+                ))
+                assert self.cache._cache == {
+                    'hit1': 'value1',
+                    'hit2': 'value2',
+                    'hit3': 'value3',
+                    'first': 'rajiv',
+                }
+                assert self.cache.misses() == {'miss1', 'miss2', 'miss3'}
+
+        self.cache.setdefault('miss1', default='value1')
+        assert self.cache == collections.OrderedDict((
+            ('hit1', 'value1'),
+            ('miss1', 'value1'),
+            ('hit2', 'value2'),
+            ('miss2', CachedOrderedDict._SENTINEL),
+            ('hit3', 'value3'),
+            ('miss3', CachedOrderedDict._SENTINEL),
+            ('first', 'rajiv'),
+        ))
+        assert self.cache._cache == {
+            'hit1': 'value1',
+            'hit2': 'value2',
+            'hit3': 'value3',
+            'first': 'rajiv',
+            'miss1': 'value1',
+        }
+        assert self.cache.misses() == {'miss2', 'miss3'}
+
+    def test_update(self):
+        self.cache.update()
+        assert self.cache == collections.OrderedDict((
+            ('hit1', 'value1'),
+            ('miss1', CachedOrderedDict._SENTINEL),
+            ('hit2', 'value2'),
+            ('miss2', CachedOrderedDict._SENTINEL),
+            ('hit3', 'value3'),
+            ('miss3', CachedOrderedDict._SENTINEL),
+        ))
+        assert self.cache._cache == {
+            'hit1': 'value1',
+            'hit2': 'value2',
+            'hit3': 'value3',
+        }
+        assert self.cache.misses() == {'miss1', 'miss2', 'miss3'}
+
+        self.cache.update((
+            ('miss1', 'value1'),
+            ('miss2', 'value2'),
+            ('hit4', 'value4'),
+            ('hit5', 'value5'),
+        ))
+        assert self.cache == collections.OrderedDict((
+            ('hit1', 'value1'),
+            ('miss1', 'value1'),
+            ('hit2', 'value2'),
+            ('miss2', 'value2'),
+            ('hit3', 'value3'),
+            ('miss3', CachedOrderedDict._SENTINEL),
+            ('hit4', 'value4'),
+            ('hit5', 'value5'),
+        ))
+        assert self.cache._cache == {
+            'hit1': 'value1',
+            'hit2': 'value2',
+            'hit3': 'value3',
+            'miss1': 'value1',
+            'miss2': 'value2',
+            'hit4': 'value4',
+            'hit5': 'value5',
+        }
+        assert self.cache.misses() == {'miss3'}

--- a/tests/test_dict.py
+++ b/tests/test_dict.py
@@ -105,6 +105,33 @@ class DictTests(TestCase):
         a.update()
         assert a == {'one': 1, 'two': 2, 'three': 3}
 
+        a.update({'four': 4, 'five': 5})
+        assert a == {'one': 1, 'two': 2, 'three': 3, 'four': 4, 'five': 5}
+
+        a.update((('six', 6), ('seven', 7)))
+        assert a == {
+            'one': 1,
+            'two': 2,
+            'three': 3,
+            'four': 4,
+            'five': 5,
+            'six': 6,
+            'seven': 7,
+        }
+
+        a.update(eight=8, nine=9)
+        assert a == {
+            'one': 1,
+            'two': 2,
+            'three': 3,
+            'four': 4,
+            'five': 5,
+            'six': 6,
+            'seven': 7,
+            'eight': 8,
+            'nine': 9,
+        }
+
     def test_keyerror(self):
         a = RedisDict(one=1, two=2, three=3)
         assert a['one'] == 1

--- a/tests/test_hyper.py
+++ b/tests/test_hyper.py
@@ -13,13 +13,7 @@ from tests.base import TestCase
 
 
 class HyperLogLogTests(TestCase):
-    def setUp(self):
-        super().setUp()
-        self.redis.delete('hll')
-
-    def tearDown(self):
-        self.redis.delete('hll')
-        super().tearDown()
+    _KEY = '{}hll'.format(TestCase._TEST_KEY_PREFIX)
 
     def test_init_without_iterable(self):
         hll = HyperLogLog()
@@ -78,5 +72,5 @@ class HyperLogLogTests(TestCase):
 
     def test_repr(self):
         'Test HyperLogLog.__repr__()'
-        hll = HyperLogLog({'foo', 'bar', 'zap', 'a'}, key='hll')
-        assert repr(hll) == '<HyperLogLog key=hll len=4>'
+        hll = HyperLogLog({'foo', 'bar', 'zap', 'a'}, key=self._KEY)
+        assert repr(hll) == '<HyperLogLog key={} len=4>'.format(self._KEY)

--- a/tests/test_list.py
+++ b/tests/test_list.py
@@ -19,16 +19,18 @@ class ListTests(TestCase):
         https://docs.python.org/3/tutorial/datastructures.html#more-on-lists
     '''
 
+    _KEY = '{}squares'.format(TestCase._TEST_KEY_PREFIX)
+
     def test_indexerror(self):
         list_ = RedisList()
         with self.assertRaises(IndexError):
             list_[0] = 'raj'
 
     def test_keyexistserror(self):
-        squares = RedisList((1, 4, 9, 16, 25), key='pottery:squares')
+        squares = RedisList((1, 4, 9, 16, 25), key=self._KEY)
         squares     # Workaround for Pyflakes.  :-(
         with self.assertRaises(KeyExistsError):
-            RedisList((1, 4, 9, 16, 25), key='pottery:squares')
+            RedisList((1, 4, 9, 16, 25), key=self._KEY)
 
     def test_basic_usage(self):
         squares = RedisList((1, 4, 9, 16, 25))
@@ -136,37 +138,39 @@ class ListTests(TestCase):
             squares.sort(key=str)
 
     def test_eq_same_redis_instance_and_key(self):
-        squares1 = RedisList((1, 4, 9, 16, 25), key='pottery:squares')
-        squares2 = RedisList(key='pottery:squares')
+        squares1 = RedisList((1, 4, 9, 16, 25), key=self._KEY)
+        squares2 = RedisList(key=self._KEY)
         assert squares1 == squares2
         assert not squares1 != squares2
 
     def test_eq_same_redis_instance_different_keys(self):
-        squares1 = RedisList((1, 4, 9, 16, 25), key='pottery:squares1')
-        squares2 = RedisList((1, 4, 9, 16, 25), key='pottery:squares2')
+        key1 = '{}squares1'.format(TestCase._TEST_KEY_PREFIX)
+        key2 = '{}squares2'.format(TestCase._TEST_KEY_PREFIX)
+        squares1 = RedisList((1, 4, 9, 16, 25), key=key1)
+        squares2 = RedisList((1, 4, 9, 16, 25), key=key2)
         assert squares1 == squares2
         assert not squares1 != squares2
 
     def test_eq_different_lengths(self):
-        squares1 = RedisList((1, 4, 9, 16, 25), key='pottery:squares')
+        squares1 = RedisList((1, 4, 9, 16, 25))
         squares2 = (1, 4, 9, 16, 25, 36)
         assert not squares1 == squares2
         assert squares1 != squares2
 
     def test_eq_different_items(self):
-        squares1 = RedisList((1, 4, 9, 16, 25), key='pottery:squares')
+        squares1 = RedisList((1, 4, 9, 16, 25))
         squares2 = (4, 9, 16, 25, 36)
         assert not squares1 == squares2
         assert squares1 != squares2
 
     def test_eq_unordered_collection(self):
-        squares1 = RedisList((1,), key='pottery:squares')
+        squares1 = RedisList((1,))
         squares2 = {1}
         assert not squares1 == squares2
         assert squares1 != squares2
 
     def test_eq_typeerror(self):
-        squares = RedisList((1, 4, 9, 16, 25), key='pottery:squares')
+        squares = RedisList((1, 4, 9, 16, 25))
         assert not squares == None
         assert squares != None
 

--- a/tests/test_source.py
+++ b/tests/test_source.py
@@ -12,7 +12,6 @@ import itertools
 import os
 import sys
 import unittest
-import warnings
 
 from isort import SortImports
 
@@ -26,14 +25,6 @@ monkey  # Workaround for Pyflakes.  :-(
 
 
 class SourceTests(TestCase):
-    def setUp(self):
-        super().setUp()
-        warnings.filterwarnings('ignore', category=DeprecationWarning)
-
-    def tearDown(self):
-        warnings.filterwarnings('default', category=DeprecationWarning)
-        super().tearDown()
-
     @unittest.skipIf(
         sys.version_info[:2] == (3, 5),
         'isort is broken on Python 3.5 for no good reason ¯\\_(ツ)_/¯'


### PR DESCRIPTION
Refactor `CachedOrderedDict` to be useful standalone, similar to
`collections.OrderedDict`.  Before this refactoring, `CachedOrderedDict`
was only useful as a context manager.  After this refactoring,
`CachedOrderedDict` can still be used as a context manager.