### PR TITLE
Fix the unittest.mock.patch import

### DIFF
--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -10,7 +10,7 @@
 import collections
 import random
 import time
-import unittest
+from unittest import mock
 
 from pottery import redis_cache
 from pottery.cache import _DEFAULT_TIMEOUT
@@ -162,7 +162,7 @@ class CacheDecoratorTests(TestCase):
             currsize=1,
         )
 
-    @unittest.mock.patch('random.getrandbits')
+    @mock.patch('random.getrandbits')
     def test_bypass(self, getrandbits):
         getrandbits.return_value = 5
 

--- a/tests/test_source.py
+++ b/tests/test_source.py
@@ -25,6 +25,10 @@ monkey  # Workaround for Pyflakes.  :-(
 
 
 class SourceTests(TestCase):
+    _EXCLUDES = (
+        '/__init__.py',
+    )
+
     @unittest.skipIf(
         sys.version_info[:2] == (3, 5),
         'isort is broken on Python 3.5 for no good reason ¯\\_(ツ)_/¯'
@@ -35,12 +39,19 @@ class SourceTests(TestCase):
             f for f in os.listdir(test_dir, absolute=True) if f.endswith('.py')
         )
 
-        source_dir = os.path.dirname(test_dir)
+        root_dir = os.path.dirname(test_dir)
+        root_files = (
+            f for f in os.listdir(root_dir, absolute=True)
+            if f.endswith('.py')
+        )
+
+        source_dir = os.path.join(root_dir, 'pottery')
         source_files = (
             f for f in os.listdir(source_dir, absolute=True)
             if f.endswith('.py')
         )
 
-        for f in itertools.chain(source_files, test_files):
-            with self.subTest(f=f):
-                assert SortImports(f, check=True).correctly_sorted
+        for f in itertools.chain(test_files, root_files, source_files):
+            if not f.endswith(self._EXCLUDES):
+                with self.subTest(f=f):
+                    assert SortImports(f, check=True).correctly_sorted


### PR DESCRIPTION
When doing `import unittest` and invoking the test suite like so `$ make
test tests=tests.test_cache.CachedOrderedDictTests.test_update`, I got
the following error: `AttributeError: module 'unittest' has no attribute
'mock'`.

Apparently, the fix is to change `import unittest` to `from
unittest.mock import patch`.

Source:
https://github.com/coala/coala-bears/issues/2862#issuecomment-461139198