### PR TITLE
Remove CachedOrderedDict context manager

### DIFF
--- a/pottery/__init__.py
+++ b/pottery/__init__.py
@@ -14,7 +14,7 @@ know how to use Pottery.
 
 
 __title__ = 'pottery'
-__version__ = '0.64'
+__version__ = '0.65'
 __description__, __long_description__ = (
     s.strip() for s in __doc__.split(sep='\n\n', maxsplit=1)
 )

--- a/pottery/cache.py
+++ b/pottery/cache.py
@@ -188,12 +188,6 @@ class CachedOrderedDict(collections.OrderedDict):
                 self._cache.redis.multi()
                 self._cache[key] = default
 
-    def __enter__(self):
-        return self
-
-    def __exit__(self, exc_type, exc_value, traceback):
-        pass
-
     def _retry(self, partial, try_num=0):
         try:
             return partial()

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -246,14 +246,14 @@ class CachedOrderedDictTests(TestCase):
         super().setUp()
 
         # Populate the cache with three hits:
-        with CachedOrderedDict(
+        cache = CachedOrderedDict(
             redis=self.redis,
             key=self._KEY,
             keys=('hit1', 'hit2', 'hit3'),
-        ) as cache:
-            cache['hit1'] = 'value1'
-            cache['hit2'] = 'value2'
-            cache['hit3'] = 'value3'
+        )
+        cache['hit1'] = 'value1'
+        cache['hit2'] = 'value2'
+        cache['hit3'] = 'value3'
 
         # Instantiate the cache again with the three hits and three misses:
         self.cache = CachedOrderedDict(


### PR DESCRIPTION
We now do the heavy lifting regarding caching and persistence in the
`__setitem__()` and `setdefault()` methods, so there's no longer any
reason to use `CachedOrderedDict` as a context manager.