### PR TITLE
Expose no expiration for redis_cache() decorator

### DIFF
--- a/pottery/__init__.py
+++ b/pottery/__init__.py
@@ -13,7 +13,7 @@ know how to use Pottery.
 
 
 __title__ = 'pottery'
-__version__ = '0.65'
+__version__ = '0.66'
 __description__, __long_description__ = (
     s.strip() for s in __doc__.split(sep='\n\n', maxsplit=1)
 )

--- a/pottery/cache.py
+++ b/pottery/cache.py
@@ -105,7 +105,8 @@ def redis_cache(*, redis=None, key=None, timeout=_DEFAULT_TIMEOUT):
                 return_value = func(*args, **kwargs)
                 cache[hash_] = return_value
                 misses += 1
-            redis.expire(key, timeout)
+            if timeout:
+                redis.expire(key, timeout)
             return return_value
 
         @functools.wraps(func)
@@ -113,7 +114,8 @@ def redis_cache(*, redis=None, key=None, timeout=_DEFAULT_TIMEOUT):
             hash_ = _arg_hash(*args, **kwargs)
             return_value = func(*args, **kwargs)
             cache[hash_] = return_value
-            redis.expire(key, timeout)
+            if timeout:
+                redis.expire(key, timeout)
             return return_value
 
         def cache_info():

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -19,63 +19,77 @@ from tests.base import TestCase
 
 
 class CacheDecoratorTests(TestCase):
-    _KEY = '{}expensive-method'.format(TestCase._TEST_KEY_PREFIX)
+    _KEY_EXPIRATION = '{}expensive-method-expiration'.format(
+        TestCase._TEST_KEY_PREFIX,
+    )
+
+    _KEY_NO_EXPIRATION = '{}expensive-method-no-expiration'.format(
+        TestCase._TEST_KEY_PREFIX,
+    )
 
     def setUp(self):
         super().setUp()
-        self.expensive_method.cache_clear()
+        self.expensive_method_expiration.cache_clear()
+        self.expensive_method_no_expiration.cache_clear()
 
     def tearDown(self):
-        self.expensive_method.cache_clear()
+        self.expensive_method_expiration.cache_clear()
+        self.expensive_method_no_expiration.cache_clear()
         super().tearDown()
 
     @staticmethod
-    @redis_cache(key=_KEY)
-    def expensive_method(*args, **kwargs):
+    @redis_cache(key=_KEY_EXPIRATION)
+    def expensive_method_expiration(*args, **kwargs):
+        'getrandbits(16) -> x.  Generates a 16-bit random int.'
+        return random.getrandbits(16)
+
+    @staticmethod
+    @redis_cache(key=_KEY_NO_EXPIRATION, timeout=None)
+    def expensive_method_no_expiration(*args, **kwargs):
         'getrandbits(16) -> x.  Generates a 16-bit random int.'
         return random.getrandbits(16)
 
     def test_cache(self):
-        assert self.expensive_method.cache_info() == CacheInfo(
+        assert self.expensive_method_expiration.cache_info() == CacheInfo(
             hits=0,
             misses=0,
             maxsize=None,
             currsize=0,
         )
 
-        value1 = self.expensive_method()
-        assert self.expensive_method.cache_info() == CacheInfo(
+        value1 = self.expensive_method_expiration()
+        assert self.expensive_method_expiration.cache_info() == CacheInfo(
             hits=0,
             misses=1,
             maxsize=None,
             currsize=1,
         )
-        assert self.expensive_method() == value1
-        assert self.expensive_method.cache_info() == CacheInfo(
+        assert self.expensive_method_expiration() == value1
+        assert self.expensive_method_expiration.cache_info() == CacheInfo(
             hits=1,
             misses=1,
             maxsize=None,
             currsize=1,
         )
 
-        value2 = self.expensive_method('raj')
-        assert self.expensive_method.cache_info() == CacheInfo(
+        value2 = self.expensive_method_expiration('raj')
+        assert self.expensive_method_expiration.cache_info() == CacheInfo(
             hits=1,
             misses=2,
             maxsize=None,
             currsize=2,
         )
         assert value2 != value1
-        assert self.expensive_method('raj') == value2
-        assert self.expensive_method.cache_info() == CacheInfo(
+        assert self.expensive_method_expiration('raj') == value2
+        assert self.expensive_method_expiration.cache_info() == CacheInfo(
             hits=2,
             misses=2,
             maxsize=None,
             currsize=2,
         )
 
-        value3 = self.expensive_method(first='raj', last='shah')
-        assert self.expensive_method.cache_info() == CacheInfo(
+        value3 = self.expensive_method_expiration(first='raj', last='shah')
+        assert self.expensive_method_expiration.cache_info() == CacheInfo(
             hits=2,
             misses=3,
             maxsize=None,
@@ -83,16 +97,16 @@ class CacheDecoratorTests(TestCase):
         )
         assert value3 != value1
         assert value3 != value2
-        assert self.expensive_method(first='raj', last='shah') == value3
-        assert self.expensive_method.cache_info() == CacheInfo(
+        assert self.expensive_method_expiration(first='raj', last='shah') == value3
+        assert self.expensive_method_expiration.cache_info() == CacheInfo(
             hits=3,
             misses=3,
             maxsize=None,
             currsize=3,
         )
 
-        value4 = self.expensive_method(last='shah', first='raj')
-        assert self.expensive_method.cache_info() == CacheInfo(
+        value4 = self.expensive_method_expiration(last='shah', first='raj')
+        assert self.expensive_method_expiration.cache_info() == CacheInfo(
             hits=4,
             misses=3,
             maxsize=None,
@@ -100,8 +114,8 @@ class CacheDecoratorTests(TestCase):
         )
         assert value4 == value3
 
-        value5 = self.expensive_method('raj', last='shah')
-        assert self.expensive_method.cache_info() == CacheInfo(
+        value5 = self.expensive_method_expiration('raj', last='shah')
+        assert self.expensive_method_expiration.cache_info() == CacheInfo(
             hits=4,
             misses=4,
             maxsize=None,
@@ -111,8 +125,8 @@ class CacheDecoratorTests(TestCase):
         assert value5 != value2
         assert value5 != value3
         assert value5 != value4
-        assert self.expensive_method('raj', last='shah') == value5
-        assert self.expensive_method.cache_info() == CacheInfo(
+        assert self.expensive_method_expiration('raj', last='shah') == value5
+        assert self.expensive_method_expiration.cache_info() == CacheInfo(
             hits=5,
             misses=4,
             maxsize=None,
@@ -120,40 +134,72 @@ class CacheDecoratorTests(TestCase):
         )
 
     def test_expiration(self):
-        self.expensive_method()
-        assert self.redis.ttl(self._KEY) == _DEFAULT_TIMEOUT
+        self.expensive_method_expiration()
+        assert self.redis.ttl(self._KEY_EXPIRATION) == _DEFAULT_TIMEOUT
         time.sleep(1)
-        assert self.redis.ttl(self._KEY) == _DEFAULT_TIMEOUT - 1
+        assert self.redis.ttl(self._KEY_EXPIRATION) == _DEFAULT_TIMEOUT - 1
 
-        self.expensive_method()
-        assert self.redis.ttl(self._KEY) == _DEFAULT_TIMEOUT
+        self.expensive_method_expiration()
+        assert self.redis.ttl(self._KEY_EXPIRATION) == _DEFAULT_TIMEOUT
         time.sleep(1)
-        assert self.redis.ttl(self._KEY) == _DEFAULT_TIMEOUT - 1
+        assert self.redis.ttl(self._KEY_EXPIRATION) == _DEFAULT_TIMEOUT - 1
 
-        self.expensive_method('raj')
-        assert self.redis.ttl(self._KEY) == _DEFAULT_TIMEOUT
+        self.expensive_method_expiration('raj')
+        assert self.redis.ttl(self._KEY_EXPIRATION) == _DEFAULT_TIMEOUT
+
+        self.expensive_method_expiration.__bypass__()
+        assert self.redis.ttl(self._KEY_EXPIRATION) == _DEFAULT_TIMEOUT
+        time.sleep(1)
+        assert self.redis.ttl(self._KEY_EXPIRATION) == _DEFAULT_TIMEOUT - 1
+
+        self.expensive_method_expiration.__bypass__()
+        assert self.redis.ttl(self._KEY_EXPIRATION) == _DEFAULT_TIMEOUT
+        time.sleep(1)
+        assert self.redis.ttl(self._KEY_EXPIRATION) == _DEFAULT_TIMEOUT - 1
+
+        self.expensive_method_expiration.__bypass__('raj')
+        assert self.redis.ttl(self._KEY_EXPIRATION) == _DEFAULT_TIMEOUT
+
+    def test_no_expiration(self):
+        self.expensive_method_no_expiration()
+        assert self.redis.ttl(self._KEY_NO_EXPIRATION) == -1
+
+        self.expensive_method_no_expiration()
+        assert self.redis.ttl(self._KEY_NO_EXPIRATION) == -1
+
+        self.expensive_method_no_expiration('raj')
+        assert self.redis.ttl(self._KEY_NO_EXPIRATION) == -1
+
+        self.expensive_method_no_expiration.__bypass__()
+        assert self.redis.ttl(self._KEY_NO_EXPIRATION) == -1
+
+        self.expensive_method_no_expiration.__bypass__()
+        assert self.redis.ttl(self._KEY_NO_EXPIRATION) == -1
+
+        self.expensive_method_no_expiration.__bypass__('raj')
+        assert self.redis.ttl(self._KEY_NO_EXPIRATION) == -1
 
     def test_wrapped(self):
-        value1 = self.expensive_method()
-        assert self.expensive_method() == value1
-        assert self.expensive_method.cache_info() == CacheInfo(
+        value1 = self.expensive_method_expiration()
+        assert self.expensive_method_expiration() == value1
+        assert self.expensive_method_expiration.cache_info() == CacheInfo(
             hits=1,
             misses=1,
             maxsize=None,
             currsize=1,
         )
 
-        value2 = self.expensive_method.__wrapped__()
+        value2 = self.expensive_method_expiration.__wrapped__()
         assert value2 != value1
-        assert self.expensive_method.cache_info() == CacheInfo(
+        assert self.expensive_method_expiration.cache_info() == CacheInfo(
             hits=1,
             misses=1,
             maxsize=None,
             currsize=1,
         )
 
-        assert self.expensive_method() == value1
-        assert self.expensive_method.cache_info() == CacheInfo(
+        assert self.expensive_method_expiration() == value1
+        assert self.expensive_method_expiration.cache_info() == CacheInfo(
             hits=2,
             misses=1,
             maxsize=None,
@@ -164,36 +210,36 @@ class CacheDecoratorTests(TestCase):
     def test_bypass(self, getrandbits):
         getrandbits.return_value = 5
 
-        self.expensive_method()
+        self.expensive_method_expiration()
         assert getrandbits.call_count == 1
-        assert self.expensive_method.cache_info() == CacheInfo(
+        assert self.expensive_method_expiration.cache_info() == CacheInfo(
             hits=0,
             misses=1,
             maxsize=None,
             currsize=1,
         )
 
-        self.expensive_method()
+        self.expensive_method_expiration()
         assert getrandbits.call_count == 1
-        assert self.expensive_method.cache_info() == CacheInfo(
+        assert self.expensive_method_expiration.cache_info() == CacheInfo(
             hits=1,
             misses=1,
             maxsize=None,
             currsize=1,
         )
 
-        self.expensive_method.__bypass__()
+        self.expensive_method_expiration.__bypass__()
         assert getrandbits.call_count == 2
-        assert self.expensive_method.cache_info() == CacheInfo(
+        assert self.expensive_method_expiration.cache_info() == CacheInfo(
             hits=1,
             misses=1,
             maxsize=None,
             currsize=1,
         )
 
-        self.expensive_method()
+        self.expensive_method_expiration()
         assert getrandbits.call_count == 2
-        assert self.expensive_method.cache_info() == CacheInfo(
+        assert self.expensive_method_expiration.cache_info() == CacheInfo(
             hits=2,
             misses=1,
             maxsize=None,
@@ -201,34 +247,34 @@ class CacheDecoratorTests(TestCase):
         )
 
     def test_cache_clear(self):
-        self.expensive_method()
-        assert self.expensive_method.cache_info() == CacheInfo(
+        self.expensive_method_expiration()
+        assert self.expensive_method_expiration.cache_info() == CacheInfo(
             hits=0,
             misses=1,
             maxsize=None,
             currsize=1,
         )
 
-        self.expensive_method.cache_clear()
-        assert self.expensive_method.cache_info() == CacheInfo(
+        self.expensive_method_expiration.cache_clear()
+        assert self.expensive_method_expiration.cache_info() == CacheInfo(
             hits=0,
             misses=0,
             maxsize=None,
             currsize=0,
         )
 
-        self.expensive_method()
-        self.expensive_method()
-        self.expensive_method('raj')
-        assert self.expensive_method.cache_info() == CacheInfo(
+        self.expensive_method_expiration()
+        self.expensive_method_expiration()
+        self.expensive_method_expiration('raj')
+        assert self.expensive_method_expiration.cache_info() == CacheInfo(
             hits=1,
             misses=2,
             maxsize=None,
             currsize=2,
         )
 
-        self.expensive_method.cache_clear()
-        assert self.expensive_method.cache_info() == CacheInfo(
+        self.expensive_method_expiration.cache_clear()
+        assert self.expensive_method_expiration.cache_info() == CacheInfo(
             hits=0,
             misses=0,
             maxsize=None,


### PR DESCRIPTION
The user can now specify no cache expiration by specifying
`@redis_cache(timeout=None)`.