### PR TITLE
Include pyenv Homebrew formula in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@
 # --------------------------------------------------------------------------- #
 
 
-init upgrade: formulae := {openssl,readline,xz,redis}
+init upgrade: formulae := {openssl,readline,xz,pyenv,redis}
 
 version ?= 3.8.1
 venv ?= venv


### PR DESCRIPTION
`pyenv` is a prerequisite to building Pottery. It was an oversight that
I'd left it out in the first place.