### PR TITLE
Avoid contention on WATCHed variable

### DIFF
--- a/pottery/__init__.py
+++ b/pottery/__init__.py
@@ -13,7 +13,7 @@ know how to use Pottery.
 
 
 __title__ = 'pottery'
-__version__ = '0.66'
+__version__ = '0.70'
 __description__, __long_description__ = (
     s.strip() for s in __doc__.split(sep='\n\n', maxsplit=1)
 )

--- a/pottery/deque.py
+++ b/pottery/deque.py
@@ -18,25 +18,24 @@ class RedisDeque(RedisList, collections.deque):
 
     def __init__(self, iterable=tuple(), maxlen=None, *, redis=None, key=None):
         'Initialize a RedisDeque.  O(n)'
+        if maxlen is not None and not isinstance(maxlen, int):
+            raise TypeError('an integer is required')
         self._maxlen = maxlen
         super().__init__(iterable, redis=redis, key=key)
-
-    def _populate(self, iterable=tuple()):
-        if self.maxlen is not None:
-            try:
-                if self.maxlen:
-                    iterable = tuple(iterable)[-self.maxlen:]
-                else:
-                    iterable = tuple()
-            except TypeError:
-                raise TypeError('an integer is required')
-        super()._populate(iterable)
         if not iterable and self.maxlen is not None and len(self) > self.maxlen:
             raise IndexError(
                 'persistent {} beyond its maximum size'.format(
                     self.__class__.__name__,
                 ),
             )
+
+    def _populate(self, iterable=tuple()):
+        if self.maxlen is not None:
+            if self.maxlen:
+                iterable = tuple(iterable)[-self.maxlen:]
+            else:  # pragma: no cover
+                iterable = tuple()
+        super()._populate(iterable)
 
     @property
     def maxlen(self):

--- a/pottery/dict.py
+++ b/pottery/dict.py
@@ -21,8 +21,8 @@ class RedisDict(Base, Iterable, collections.abc.MutableMapping):
     def __init__(self, iterable=tuple(), *, redis=None, key=None, **kwargs):
         'Initialize a RedisDict.  O(n)'
         super().__init__(redis=redis, key=key, **kwargs)
-        with self._watch(iterable):
-            if iterable or kwargs:
+        if iterable or kwargs:
+            with self._watch(iterable):
                 if self.redis.exists(self.key):
                     raise KeyExistsError(self.redis, self.key)
                 else:

--- a/pottery/list.py
+++ b/pottery/list.py
@@ -43,12 +43,13 @@ class RedisList(Base, collections.abc.MutableSequence):
     def __init__(self, iterable=tuple(), *, redis=None, key=None):
         'Initialize a RedisList.  O(n)'
         super().__init__(iterable, redis=redis, key=key)
-        with self._watch(iterable):
-            self._populate(iterable)
+        if iterable:
+            with self._watch(iterable):
+                self._populate(iterable)
 
     def _populate(self, iterable=tuple()):
         encoded_values = [self._encode(value) for value in iterable]
-        if encoded_values:
+        if encoded_values:  # pragma: no cover
             if self.redis.exists(self.key):
                 raise KeyExistsError(self.redis, self.key)
             else:

--- a/pottery/set.py
+++ b/pottery/set.py
@@ -20,12 +20,13 @@ class RedisSet(Base, Iterable, collections.abc.MutableSet):
     def __init__(self, iterable=tuple(), *, redis=None, key=None):
         'Initialize a RedisSet.  O(n)'
         super().__init__(iterable, redis=redis, key=key)
-        with self._watch(iterable):
-            self._populate(iterable)
+        if iterable:
+            with self._watch(iterable):
+                self._populate(iterable)
 
     def _populate(self, iterable=tuple()):
         encoded_values = {self._encode(value) for value in iterable}
-        if encoded_values:
+        if encoded_values:  # pragma: no cover
             if self.redis.exists(self.key):
                 raise KeyExistsError(self.redis, self.key)
             else:

--- a/requirements-to-freeze.txt
+++ b/requirements-to-freeze.txt
@@ -6,7 +6,7 @@
 # --------------------------------------------------------------------------- #
 
 
-redis>=3.0.0
+# redis>=3.0.0
 mmh3
 
 isort
@@ -29,3 +29,9 @@ requests>=2.20.0
 #   https://nvd.nist.gov/vuln/detail/CVE-2018-20060
 #   https://nvd.nist.gov/vuln/detail/CVE-2019-11324
 urllib3>=1.24.2
+
+# There's a bug in redis-py 3.4.0 that prevents connecting to Redis with
+# authentication (a username and password).  Until they fix it and release a
+# new version, stay on redis-py <3.4.0.  For more info:
+#   https://github.com/andymccurdy/redis-py/issues/1278
+redis>=3.0.0,<3.4.0

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ setup(
     ],
     keywords=pottery.__keywords__,
     packages=find_packages(exclude=('contrib', 'docs', 'tests*')),
-    install_requires=('redis>=3.0.0', 'mmh3'),
+    install_requires=('redis>=3.0.0,<3.4.0', 'mmh3'),
     extras_require={},
     package_data={},
     data_files=tuple(),


### PR DESCRIPTION
Most often, when instantiating a `RedisDict` or any other Redis
container, one does not supply an iterable to populate it at
instantiation time.  Therefore, only `WATCH` the container's Redis key
if the user supplies an iterable to populate it at instantiation time.