### PR TITLE
Improve performance of `CachedOrderedDict`

### DIFF
--- a/pottery/__init__.py
+++ b/pottery/__init__.py
@@ -13,7 +13,7 @@ know how to use Pottery.
 
 
 __title__ = 'pottery'
-__version__ = '0.71'
+__version__ = '0.72'
 __description__, __long_description__ = (
     s.strip() for s in __doc__.split(sep='\n\n', maxsplit=1)
 )
@@ -22,7 +22,7 @@ __author__ = 'Rajiv Bakulesh Shah'
 __author_email__ = 'brainix@gmail.com'
 __license__ = 'Apache 2.0'
 __keywords__ = 'Redis client persistent storage'
-__copyright__ = 'Copyright © 2015-2019, {}, original author.'.format(__author__)
+__copyright__ = 'Copyright © 2015-2020, {}, original author.'.format(__author__)
 
 
 from .exceptions import PotteryError  # isort:skip

--- a/pottery/cache.py
+++ b/pottery/cache.py
@@ -146,12 +146,16 @@ class CachedOrderedDict(collections.OrderedDict):
         self._misses = set()
 
         items = []
-        for key_ in keys:
-            try:
-                item = (key_, self._cache[key_])
-            except KeyError:
-                item = (key_, self._SENTINEL)
+        keys = tuple(keys)
+        encoded_keys = (self._cache._encode(key_) for key_ in keys)
+        encoded_values = redis.hmget(key, *encoded_keys)
+        for key_, encoded_value in zip(keys, encoded_values):
+            if encoded_value is None:
+                value = self._SENTINEL
                 self._misses.add(key_)
+            else:
+                value = self._cache._decode(encoded_value)
+            item = (key_, value)
             items.append(item)
         return super().__init__(items)
 


### PR DESCRIPTION
Previously when instantiating `CachedOrderedDict`, we'd do one
`redis.hget()` for every key.  Now, we do a single `redis.hmget()` for
all of the keys.