### PR TITLE
Allow creating `CachedOrderedDict` without `keys`

### DIFF
--- a/pottery/__init__.py
+++ b/pottery/__init__.py
@@ -13,7 +13,7 @@ know how to use Pottery.
 
 
 __title__ = 'pottery'
-__version__ = '0.72'
+__version__ = '0.73'
 __description__, __long_description__ = (
     s.strip() for s in __doc__.split(sep='\n\n', maxsplit=1)
 )

--- a/pottery/cache.py
+++ b/pottery/cache.py
@@ -147,16 +147,17 @@ class CachedOrderedDict(collections.OrderedDict):
 
         items = []
         keys = tuple(keys)
-        encoded_keys = (self._cache._encode(key_) for key_ in keys)
-        encoded_values = redis.hmget(key, *encoded_keys)
-        for key_, encoded_value in zip(keys, encoded_values):
-            if encoded_value is None:
-                value = self._SENTINEL
-                self._misses.add(key_)
-            else:
-                value = self._cache._decode(encoded_value)
-            item = (key_, value)
-            items.append(item)
+        if keys:
+            encoded_keys = (self._cache._encode(key_) for key_ in keys)
+            encoded_values = redis.hmget(key, *encoded_keys)
+            for key_, encoded_value in zip(keys, encoded_values):
+                if encoded_value is None:
+                    value = self._SENTINEL
+                    self._misses.add(key_)
+                else:
+                    value = self._cache._decode(encoded_value)
+                item = (key_, value)
+                items.append(item)
         return super().__init__(items)
 
     def misses(self):

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -442,3 +442,8 @@ class CachedOrderedDictTests(TestCase):
             'hit5': 'value5',
         }
         assert self.cache.misses() == {'miss3'}
+
+    def test_no_keys(self):
+        cache = CachedOrderedDict(redis=self.redis)
+        assert cache == {}
+        assert cache.misses() == set()


### PR DESCRIPTION
Previously, instanting `CachedOrderedDict` without supplying a list of
`keys`, we'd throw a `TypeError`.  No longer!