### PR TITLE
Don't be afraid of floating point

### DIFF
--- a/pottery/dict.py
+++ b/pottery/dict.py
@@ -88,7 +88,7 @@ class RedisDict(Base, Iterable_, collections.abc.MutableMapping):
 
     def __len__(self) -> int:
         'Return the number of items in a RedisDict.  O(1)'
-        return cast(int, self.redis.hlen(self.key))
+        return self.redis.hlen(self.key)
 
     # Methods required for Raj's sanity:
 
@@ -109,6 +109,6 @@ class RedisDict(Base, Iterable_, collections.abc.MutableMapping):
     def __contains__(self, key: Any) -> bool:
         'd.__contains__(key) <==> key in d.  O(1)'
         try:
-            return bool(self.redis.hexists(self.key, self._encode(key)))
+            return self.redis.hexists(self.key, self._encode(key))
         except TypeError:
             return False

--- a/pottery/timer.py
+++ b/pottery/timer.py
@@ -45,8 +45,8 @@ class ContextTimer:
     '''
 
     def __init__(self) -> None:
-        self._started = 0
-        self._stopped = 0
+        self._started = 0.0
+        self._stopped = 0.0
 
     def __enter__(self) -> 'ContextTimer':
         self.start()
@@ -65,24 +65,22 @@ class ContextTimer:
         elif self._started:
             raise RuntimeError('timer has already been started')
         else:
-            self._started = self._now()
+            self._started = timeit.default_timer()
 
     def stop(self) -> None:
         if self._stopped:
             raise RuntimeError('timer has already been stopped')
         elif self._started:
-            self._stopped = self._now()
+            self._stopped = timeit.default_timer()
         else:
             raise RuntimeError("timer hasn't yet been started")
 
     def elapsed(self) -> int:
         if self._started:
-            return (self._stopped or self._now()) - self._started
+            elapsed = (self._stopped or timeit.default_timer()) - self._started
+            return round(elapsed * 1000)
         else:
             raise RuntimeError("timer hasn't yet been started")
-
-    def _now(self) -> int:
-        return round(timeit.default_timer() * 1000)
 
 
 if __name__ == '__main__':  # pragma: no cover

--- a/tests/base.py
+++ b/tests/base.py
@@ -9,6 +9,7 @@
 import doctest
 import sys
 import unittest
+from typing import ClassVar
 from typing import NoReturn
 
 from pottery.base import Base
@@ -16,7 +17,7 @@ from pottery.base import _default_redis
 
 
 class TestCase(unittest.TestCase):
-    _TEST_KEY_PREFIX = 'pottery-test:'
+    _TEST_KEY_PREFIX: ClassVar[str] = 'pottery-test:'
 
     def setUp(self) -> None:
         super().setUp()


### PR DESCRIPTION
Keep the time on `ContextTimer` in floating point.  Only cast it to an
integer when returning it in `elapsed()`.