### PR TITLE
Implement CachedOrderedDict.update()

### DIFF
--- a/pottery/__init__.py
+++ b/pottery/__init__.py
@@ -13,7 +13,7 @@ know how to use Pottery.
 
 
 __title__ = 'pottery'
-__version__ = '0.77'
+__version__ = '0.78'
 __description__, __long_description__ = (
     s.strip() for s in __doc__.split(sep='\n\n', maxsplit=1)
 )

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -443,6 +443,51 @@ class CachedOrderedDictTests(TestCase):
         }
         assert self.cache.misses() == {'miss3'}
 
+        self.cache.update({'miss3': CachedOrderedDict._SENTINEL})
+        assert self.cache == collections.OrderedDict((
+            ('hit1', 'value1'),
+            ('miss1', 'value1'),
+            ('hit2', 'value2'),
+            ('miss2', 'value2'),
+            ('hit3', 'value3'),
+            ('miss3', CachedOrderedDict._SENTINEL),
+            ('hit4', 'value4'),
+            ('hit5', 'value5'),
+        ))
+        assert self.cache._cache == {
+            'hit1': 'value1',
+            'hit2': 'value2',
+            'hit3': 'value3',
+            'miss1': 'value1',
+            'miss2': 'value2',
+            'hit4': 'value4',
+            'hit5': 'value5',
+        }
+        assert self.cache.misses() == {'miss3'}
+
+        self.cache.update(miss3='value3')
+        assert self.cache == collections.OrderedDict((
+            ('hit1', 'value1'),
+            ('miss1', 'value1'),
+            ('hit2', 'value2'),
+            ('miss2', 'value2'),
+            ('hit3', 'value3'),
+            ('miss3', 'value3'),
+            ('hit4', 'value4'),
+            ('hit5', 'value5'),
+        ))
+        assert self.cache._cache == {
+            'hit1': 'value1',
+            'hit2': 'value2',
+            'hit3': 'value3',
+            'miss1': 'value1',
+            'miss2': 'value2',
+            'hit4': 'value4',
+            'hit5': 'value5',
+            'miss3': 'value3',
+        }
+        assert self.cache.misses() == set()
+
     def test_non_string_keys(self):
         assert self.cache == collections.OrderedDict((
             ('hit1', 'value1'),


### PR DESCRIPTION
The base class, `collections.OrderedDict`, has an `update()` method
which works.  However, by overriding it in our subclass, we can prevent
multiple calls to `__setitem__()` and therefore multiple round-trips to
Redis.