### PR TITLE
Override Counter.most_common() for efficiency

### DIFF
--- a/pottery/__init__.py
+++ b/pottery/__init__.py
@@ -13,7 +13,7 @@ know how to use Pottery.
 
 
 __title__ = 'pottery'
-__version__ = '0.78'
+__version__ = '0.79'
 __description__, __long_description__ = (
     s.strip() for s in __doc__.split(sep='\n\n', maxsplit=1)
 )


### PR DESCRIPTION
The parent class's `.most_common()` works, but it issues repeated calls
to `.__getitem__()` therefore repeated calls to Redis `HGET`.

Our overridden implementation issues a few calls to `_scan()` therefore
a few calls to Redis `HSCAN`.