### PR TITLE
Switch from str.format() to f-strings

### DIFF
--- a/pottery/__init__.py
+++ b/pottery/__init__.py
@@ -22,7 +22,7 @@ __author__ = 'Rajiv Bakulesh Shah'
 __author_email__ = 'brainix@gmail.com'
 __license__ = 'Apache 2.0'
 __keywords__ = 'Redis client persistent storage'
-__copyright__ = 'Copyright © 2015-2020, {}, original author.'.format(__author__)
+__copyright__ = f'Copyright © 2015-2020, {__author__}, original author.'
 
 
 from .exceptions import PotteryError  # isort:skip

--- a/pottery/base.py
+++ b/pottery/base.py
@@ -295,4 +295,4 @@ class Primitive(metaclass=abc.ABCMeta):
 
     @key.setter
     def key(self, value: str) -> None:
-        self._key = '{}:{}'.format(self.KEY_PREFIX, value)
+        self._key = f'{self.KEY_PREFIX}:{value}'

--- a/pottery/bloom.py
+++ b/pottery/bloom.py
@@ -293,7 +293,7 @@ class BloomFilter(BloomFilterABC, Base):
 
     def __repr__(self) -> str:
         'Return the string representation of a BloomFilter.  O(1)'
-        return '<{} key={}>'.format(self.__class__.__name__, self.key)
+        return f'<{self.__class__.__name__} key={self.key}>'
 
 
 if __name__ == '__main__':  # pragma: no cover

--- a/pottery/counter.py
+++ b/pottery/counter.py
@@ -89,7 +89,7 @@ class RedisCounter(RedisDict, collections.Counter):
     def __repr__(self) -> str:
         'Return the string representation of a RedisCounter.  O(n)'
         items = self.most_common()
-        pairs = ("'{}': {}".format(key, value) for key, value in items)
+        pairs = (f"'{key}': {value}" for key, value in items)
         repr_ = ', '.join(pairs)
         return self.__class__.__name__ + '{' + repr_ + '}'
 

--- a/pottery/deque.py
+++ b/pottery/deque.py
@@ -36,9 +36,7 @@ class RedisDeque(RedisList, collections.deque):  # type: ignore
         super().__init__(iterable, redis=redis, key=key)
         if not iterable and self.maxlen is not None and len(self) > self.maxlen:
             raise IndexError(
-                'persistent {} beyond its maximum size'.format(
-                    self.__class__.__name__,
-                ),
+                f'persistent {self.__class__.__name__} beyond its maximum size'
             )
 
     def _populate(self,
@@ -59,18 +57,15 @@ class RedisDeque(RedisList, collections.deque):  # type: ignore
     @maxlen.setter
     def maxlen(self, value: int) -> None:
         raise AttributeError(
-            "attribute 'maxlen' of '{}' objects is not writable".format(
-                self.__class__.__name__,
-            ),
+            f"attribute 'maxlen' of '{self.__class__.__name__}' objects is not "
+            'writable'
         )
 
     def insert(self, index: int, value: JSONTypes) -> None:
         'Insert an element into a RedisDeque before the given index.  O(n)'
         if self.maxlen is not None and len(self) >= self.maxlen:
             raise IndexError(
-                '{} already at its maximum size'.format(
-                    self.__class__.__name__,
-                ),
+                f'{self.__class__.__name__} already at its maximum size'
             )
         else:
             return super()._insert(index, value)
@@ -147,6 +142,6 @@ class RedisDeque(RedisList, collections.deque):  # type: ignore
         values = [self._decode(value) for value in encoded]
         repr = self.__class__.__name__ + '(' + str(values)
         if self.maxlen is not None:
-            repr += ', maxlen={}'.format(self.maxlen)
+            repr += f', maxlen={self.maxlen}'
         repr += ')'
         return repr

--- a/pottery/exceptions.py
+++ b/pottery/exceptions.py
@@ -20,14 +20,12 @@ class PotteryError(Exception):
         self._key = key
 
     def __repr__(self) -> str:
-        return "{}(redis={}, key='{}')".format(
-            self.__class__.__name__,
-            self._redis,
-            self._key,
+        return (
+            f"{self.__class__.__name__}(redis={self._redis}, key='{self._key}')"
         )
 
     def __str__(self) -> str:
-        return "redis={} key='{}'".format(self._redis, self._key)
+        return f"redis={self._redis} key='{self._key}'"
 
 class KeyExistsError(PotteryError):
     'Initializing a container on a Redis key that already exists.'
@@ -39,10 +37,10 @@ class RandomKeyError(PotteryError, RuntimeError):
         super().__init__(redis, None)
 
     def __repr__(self) -> str:
-        return "{}(redis={})".format(self.__class__.__name__, self._redis)
+        return f"{self.__class__.__name__}(redis={self._redis})"
 
     def __str__(self) -> str:
-        return 'redis={}'.format(self._redis)
+        return f'redis={self._redis}'
 
 
 class PrimitiveError(Exception):
@@ -53,14 +51,13 @@ class PrimitiveError(Exception):
         self._key = key
 
     def __repr__(self) -> str:
-        return "{}(masters={}, key='{}')".format(
-            self.__class__.__name__,
-            list(self._masters),
-            self._key,
+        return (
+            f"{self.__class__.__name__}(masters={list(self._masters)}, "
+            f"key='{self._key}')"
         )
 
     def __str__(self) -> str:
-        return "masters={}, key='{}'".format(list(self._masters), self._key)
+        return f"masters={list(self._masters)}, key='{self._key}'"
 
 class QuorumNotAchieved(PrimitiveError, RuntimeError):
     ...

--- a/pottery/hyper.py
+++ b/pottery/hyper.py
@@ -84,8 +84,4 @@ class HyperLogLog(Base):
 
     def __repr__(self) -> str:
         'Return the string representation of a HyperLogLog.  O(1)'
-        return '<{} key={} len={}>'.format(
-            self.__class__.__name__,
-            self.key,
-            len(self),
-        )
+        return f'<{self.__class__.__name__} key={self.key} len={len(self)}>'

--- a/pottery/list.py
+++ b/pottery/list.py
@@ -259,7 +259,7 @@ class RedisList(Base, collections.abc.MutableSequence):
                 encoded_value = pipeline.execute()[0]
                 if encoded_value is None:
                     raise IndexError(
-                        'pop from an empty {}'.format(self.__class__.__name__),
+                        f'pop from an empty {self.__class__.__name__}'
                     )
                 else:
                     return self._decode(encoded_value)
@@ -276,11 +276,8 @@ class RedisList(Base, collections.abc.MutableSequence):
                     self.__delete(pipeline, index)
                     break
             else:
-                raise ValueError(
-                    '{class_}.remove(x): x not in {class_}'.format(
-                        class_=self.__class__.__name__,
-                    ),
-                )
+                class_ = self.__class__.__name__
+                raise ValueError(f'{class_}.remove(x): x not in {class_}')
 
     def to_list(self) -> List[JSONTypes]:
         return list(self)

--- a/pottery/nextid.py
+++ b/pottery/nextid.py
@@ -112,10 +112,9 @@ class NextId(Primitive):
             raise QuorumNotAchieved(self.masters, self.key)
 
     def __repr__(self) -> str:
-        return '<{} key={} value={}>'.format(
-            self.__class__.__name__,
-            self.key,
-            self.__current_id,
+        return (
+            f'<{self.__class__.__name__} key={self.key} '
+            f'value={self.__current_id}>'
         )
 
     @property

--- a/pottery/redlock.py
+++ b/pottery/redlock.py
@@ -463,11 +463,9 @@ class Redlock(Primitive):
         self.__release()
 
     def __repr__(self) -> str:
-        return '<{} key={} value={!r} timeout={}>'.format(
-            self.__class__.__name__,
-            self.key,
-            self._value,
-            self.__locked(),
+        return (
+            f'<{self.__class__.__name__} key={self.key} '
+            f'value={str(self._value)} timeout={self.__locked()}>'
         )
 
 

--- a/tests/test_bloom.py
+++ b/tests/test_bloom.py
@@ -15,7 +15,7 @@ from tests.base import TestCase  # type: ignore
 
 
 class BloomFilterTests(TestCase):
-    _KEY = '{}dilberts'.format(TestCase._TEST_KEY_PREFIX)
+    _KEY = f'{TestCase._TEST_KEY_PREFIX}dilberts'
 
     def test_init_without_iterable(self):
         'Test BloomFilter.__init__() without an iterable for initialization'
@@ -167,13 +167,13 @@ class BloomFilterTests(TestCase):
             false_positives=0.01,
             key=self._KEY,
         )
-        assert repr(dilberts) == '<BloomFilter key={}>'.format(self._KEY)
+        assert repr(dilberts) == f'<BloomFilter key={self._KEY}>'
 
 
 class RecentlyConsumedTests(TestCase):
     "Simulate reddit's recently consumed problem to test our Bloom filter."
 
-    _KEY = '{}recently-consumed'.format(TestCase._TEST_KEY_PREFIX)
+    _KEY = f'{TestCase._TEST_KEY_PREFIX}recently-consumed'
 
     def setUp(self):
         super().setUp()
@@ -240,5 +240,5 @@ class RecentlyConsumedTests(TestCase):
         actual /= len(self.unseen_links)
         actual = self.round(actual, sig_digits=1)
 
-        message = 'acceptable: {}; actual: {}'.format(acceptable, actual)
+        message = f'acceptable: {acceptable}; actual: {actual}'
         assert actual <= acceptable, message

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -19,13 +19,8 @@ from tests.base import TestCase  # type: ignore
 
 
 class CacheDecoratorTests(TestCase):
-    _KEY_EXPIRATION = '{}expensive-method-expiration'.format(
-        TestCase._TEST_KEY_PREFIX,
-    )
-
-    _KEY_NO_EXPIRATION = '{}expensive-method-no-expiration'.format(
-        TestCase._TEST_KEY_PREFIX,
-    )
+    _KEY_EXPIRATION = f'{TestCase._TEST_KEY_PREFIX}expensive-method-expiration'
+    _KEY_NO_EXPIRATION = f'{TestCase._TEST_KEY_PREFIX}expensive-method-no-expiration'
 
     def setUp(self):
         super().setUp()
@@ -283,7 +278,7 @@ class CacheDecoratorTests(TestCase):
 
 
 class CachedOrderedDictTests(TestCase):
-    _KEY = '{}cached-ordereddict'.format(TestCase._TEST_KEY_PREFIX)
+    _KEY = f'{TestCase._TEST_KEY_PREFIX}cached-ordereddict'
 
     def setUp(self):
         super().setUp()

--- a/tests/test_doctests.py
+++ b/tests/test_doctests.py
@@ -22,7 +22,7 @@ class DoctestTests(TestCase):  # pragma: no cover
         source_files = (f for f in os.listdir(source_dir) if f.endswith('.py'))
         for source_file in source_files:
             module_name = os.path.splitext(source_file)[0]
-            module = importlib.import_module('pottery.{}'.format(module_name))
+            module = importlib.import_module(f'pottery.{module_name}')
             yield module
 
     @unittest.skipUnless('CI' in os.environ, 'run (slow) doctests on only CI')

--- a/tests/test_hyper.py
+++ b/tests/test_hyper.py
@@ -11,7 +11,7 @@ from tests.base import TestCase  # type: ignore
 
 
 class HyperLogLogTests(TestCase):
-    _KEY = '{}hll'.format(TestCase._TEST_KEY_PREFIX)
+    _KEY = f'{TestCase._TEST_KEY_PREFIX}hll'
 
     def test_init_without_iterable(self):
         hll = HyperLogLog()
@@ -71,4 +71,4 @@ class HyperLogLogTests(TestCase):
     def test_repr(self):
         'Test HyperLogLog.__repr__()'
         hll = HyperLogLog({'foo', 'bar', 'zap', 'a'}, key=self._KEY)
-        assert repr(hll) == '<HyperLogLog key={} len=4>'.format(self._KEY)
+        assert repr(hll) == f'<HyperLogLog key={self._KEY} len=4>'

--- a/tests/test_list.py
+++ b/tests/test_list.py
@@ -19,7 +19,7 @@ class ListTests(TestCase):
         https://docs.python.org/3/tutorial/datastructures.html#more-on-lists
     '''
 
-    _KEY = '{}squares'.format(TestCase._TEST_KEY_PREFIX)
+    _KEY = f'{TestCase._TEST_KEY_PREFIX}squares'
 
     def test_indexerror(self):
         list_ = RedisList()
@@ -144,8 +144,8 @@ class ListTests(TestCase):
         assert not squares1 != squares2
 
     def test_eq_same_redis_instance_different_keys(self):
-        key1 = '{}squares1'.format(TestCase._TEST_KEY_PREFIX)
-        key2 = '{}squares2'.format(TestCase._TEST_KEY_PREFIX)
+        key1 = f'{TestCase._TEST_KEY_PREFIX}squares1'
+        key2 = f'{TestCase._TEST_KEY_PREFIX}squares2'
         squares1 = RedisList((1, 4, 9, 16, 25), key=key1)
         squares2 = RedisList((1, 4, 9, 16, 25), key=key2)
         assert squares1 == squares2

--- a/tests/test_timer.py
+++ b/tests/test_timer.py
@@ -21,7 +21,7 @@ class ContextTimerTests(TestCase):
 
     def _confirm_elapsed(self, expected):
         got = round(self.timer.elapsed() / self.ACCURACY) * self.ACCURACY
-        assert got == expected, '{} != {}'.format(got, expected)
+        assert got == expected, f'{got} != {expected}'
 
     def test_start_stop_and_elapsed(self):
         # timer hasn't been started


### PR DESCRIPTION
F-strings were introduced in Python 3.6.  They're more readable and
faster.

Now that we've dropped support for Python 3.5, we can switch from
`str.format()` to f-strings.