### PR TITLE
Simplify HyperLogLog.update()

### DIFF
--- a/pottery/hyper.py
+++ b/pottery/hyper.py
@@ -53,10 +53,13 @@ class HyperLogLog(Base):
     def update(self,
                *objs: Union['HyperLogLog', Iterable[RedisValues]],
                ) -> None:
-        objs = (self,) + tuple(objs)
+        # We have to iterate over objs multiple times, so cast it to a tuple.
+        # This allows the caller to pass in a generator for objs, and we can
+        # still iterate over it multiple times.
+        objs = tuple(objs)
         other_hll_keys: List[str] = []
         encoded_values: List[str] = []
-        with self._watch(objs[1:]) as pipeline:
+        with self._watch(objs) as pipeline:
             for obj in objs:
                 if isinstance(obj, self.__class__):
                     other_hll_keys.append(obj.key)


### PR DESCRIPTION
Previously, we were including `self.key` in `other_hll_keys` to be
merged in.

However, this is unnecessary, as we're saving the new HyperLogLog back
to `self.key`.  And according to the official documentation:

> The computed merged HyperLogLog is set to the destination variable,
> which is created if does not exist (defaulting to an empty HyperLogLog).

> If the destination variable exists, it is treated as one of the source
> sets and its cardinality will be included in the cardinality of the
> computed HyperLogLog.

For more info:
https://redis.io/commands/pfmerge