### PR TITLE
Ensure self, obj are on same Redis before PFMERGE

### DIFF
--- a/pottery/hyper.py
+++ b/pottery/hyper.py
@@ -62,7 +62,13 @@ class HyperLogLog(Base):
         with self._watch(objs) as pipeline:
             for obj in objs:
                 if isinstance(obj, self.__class__):
-                    other_hll_keys.append(obj.key)
+                    if self.redis.connection_pool == obj.redis.connection_pool:
+                        other_hll_keys.append(obj.key)
+                    else:  # pragma: no cover
+                        raise RuntimeError(
+                            f"can't update {self} with {obj} as they live on "
+                            "different Redis instances/databases"
+                        )
                 else:
                     for value in cast(Iterable[JSONTypes], obj):
                         encoded_values.append(self._encode(value))


### PR DESCRIPTION
Before, we were just ensuring that `obj` was a Redis HyperLogLog before
issuing `PFMERGE` in `HyperLogLog.update()`.

That's not enough.  We also need to ensure that `obj` lives on the same
Redis instance/database as `self` in order for `PFMERGE` to work.