### PR TITLE
In BloomFilter.__init__(), rename arg num_elements

### DIFF
--- a/README.md
+++ b/README.md
@@ -599,7 +599,7 @@ Create a `BloomFilter`:
 ```python
 >>> from pottery import BloomFilter
 >>> dilberts = BloomFilter(
-...     num_values=100,
+...     num_elements=100,
 ...     false_positives=0.01,
 ...     redis=redis,
 ...     key='dilberts',
@@ -607,13 +607,13 @@ Create a `BloomFilter`:
 >>>
 ```
 
-Here, `num_values` represents the number of elements that you expect to insert
-into your `BloomFilter`, and `false_positives` represents your acceptable false
-positive probability.  Using these two parameters, `BloomFilter` automatically
-computes its own storage size and number of times to run its hash functions on
-element insertion/lookup such that it can guarantee a false positive rate at or
-below what you can tolerate, given that you&rsquo;re going to insert your
-specified number of elements.
+Here, `num_elements` represents the number of elements that you expect to
+insert into your `BloomFilter`, and `false_positives` represents your
+acceptable false positive probability.  Using these two parameters,
+`BloomFilter` automatically computes its own storage size and number of times
+to run its hash functions on element insertion/lookup such that it can
+guarantee a false positive rate at or below what you can tolerate, given that
+you&rsquo;re going to insert your specified number of elements.
 
 Insert an element into the `BloomFilter`:
 

--- a/pottery/__init__.py
+++ b/pottery/__init__.py
@@ -13,7 +13,7 @@ know how to use Pottery.
 
 
 __title__ = 'pottery'
-__version__ = '1.0.0'
+__version__ = '1.0.1'
 __description__, __long_description__ = (
     s.strip() for s in __doc__.split(sep='\n\n', maxsplit=1)
 )

--- a/pottery/bloom.py
+++ b/pottery/bloom.py
@@ -66,7 +66,7 @@ class BloomFilterABC(metaclass=abc.ABCMeta):
     def __init__(self,
                  iterable: Iterable[JSONTypes] = frozenset(),
                  *args: Any,
-                 num_values: int,
+                 num_elements: int,
                  false_positives: float,
                  **kwargs: Any,
                  ) -> None:
@@ -77,7 +77,7 @@ class BloomFilterABC(metaclass=abc.ABCMeta):
         functions on each element.
         '''
         super().__init__(*args, **kwargs)  # type: ignore
-        self.num_values = num_values
+        self.num_elements = num_elements
         self.false_positives = false_positives
         self.update(iterable)
 
@@ -94,7 +94,7 @@ class BloomFilterABC(metaclass=abc.ABCMeta):
             https://en.wikipedia.org/wiki/Bloom_filter#Optimal_number_of_hash_functions
         '''
         size = (
-            -self.num_values
+            -self.num_elements
             * math.log(self.false_positives)
             / math.log(2)**2
         )
@@ -114,7 +114,7 @@ class BloomFilterABC(metaclass=abc.ABCMeta):
         More about the formula that this method implements:
             https://en.wikipedia.org/wiki/Bloom_filter#Optimal_number_of_hash_functions
         '''
-        num_hashes = self.size() / self.num_values * math.log(2)
+        num_hashes = self.size() / self.num_elements * math.log(2)
         num_hashes = math.ceil(num_hashes)
         return num_hashes
 
@@ -174,13 +174,13 @@ class BloomFilter(BloomFilterABC, Base):
     Instantiate a Bloom filter and clean up Redis before the doctest:
 
         >>> dilberts = BloomFilter(
-        ...     num_values=100,
+        ...     num_elements=100,
         ...     false_positives=0.01,
         ...     key='dilberts',
         ... )
         >>> dilberts.clear()
 
-    Here, num_values represents the number of elements that you expect to
+    Here, num_elements represents the number of elements that you expect to
     insert into your BloomFilter, and false_positives represents your
     acceptable false positive probability.  Using these two parameters,
     BloomFilter automatically computes its own storage size and number of times
@@ -224,7 +224,7 @@ class BloomFilter(BloomFilterABC, Base):
         Instantiate a Bloom filter:
 
             >>> dilberts = BloomFilter(
-            ...     num_values=100,
+            ...     num_elements=100,
             ...     false_positives=0.01,
             ...     key='dilberts',
             ... )

--- a/tests/test_bloom.py
+++ b/tests/test_bloom.py
@@ -19,8 +19,8 @@ class BloomFilterTests(TestCase):
 
     def test_init_without_iterable(self):
         'Test BloomFilter.__init__() without an iterable for initialization'
-        dilberts = BloomFilter(num_values=100, false_positives=0.01)
-        assert dilberts.num_values == 100
+        dilberts = BloomFilter(num_elements=100, false_positives=0.01)
+        assert dilberts.num_elements == 100
         assert dilberts.false_positives == 0.01
         assert 'rajiv' not in dilberts
         assert 'raj' not in dilberts
@@ -33,10 +33,10 @@ class BloomFilterTests(TestCase):
         'Test BloomFilter.__init__() with an iterable for initialization'
         dilberts = BloomFilter(
             {'rajiv', 'raj'},
-            num_values=100,
+            num_elements=100,
             false_positives=0.01,
         )
-        assert dilberts.num_values == 100
+        assert dilberts.num_elements == 100
         assert dilberts.false_positives == 0.01
         assert 'rajiv' in dilberts
         assert 'raj' in dilberts
@@ -51,25 +51,25 @@ class BloomFilterTests(TestCase):
 
     def test_size_and_num_hashes(self):
         'Test BloomFilter.size()'
-        dilberts = BloomFilter(num_values=100, false_positives=0.1)
+        dilberts = BloomFilter(num_elements=100, false_positives=0.1)
         assert dilberts.size() == 480
         assert dilberts.num_hashes() == 4
 
-        dilberts = BloomFilter(num_values=1000, false_positives=0.1)
+        dilberts = BloomFilter(num_elements=1000, false_positives=0.1)
         assert dilberts.size() == 4793
         assert dilberts.num_hashes() == 4
 
-        dilberts = BloomFilter(num_values=100, false_positives=0.01)
+        dilberts = BloomFilter(num_elements=100, false_positives=0.01)
         assert dilberts.size() == 959
         assert dilberts.num_hashes() == 7
 
-        dilberts = BloomFilter(num_values=1000, false_positives=0.01)
+        dilberts = BloomFilter(num_elements=1000, false_positives=0.01)
         assert dilberts.size() == 9586
         assert dilberts.num_hashes() == 7
 
     def test_add(self):
         'Test BloomFilter add(), __contains__(), and __len__()'
-        dilberts = BloomFilter(num_values=100, false_positives=0.01)
+        dilberts = BloomFilter(num_elements=100, false_positives=0.01)
         assert 'rajiv' not in dilberts
         assert 'raj' not in dilberts
         assert 'dan' not in dilberts
@@ -120,7 +120,7 @@ class BloomFilterTests(TestCase):
 
     def test_update(self):
         'Test BloomFilter update(), __contains__(), and __len__()'
-        dilberts = BloomFilter(num_values=100, false_positives=0.01)
+        dilberts = BloomFilter(num_elements=100, false_positives=0.01)
         assert 'rajiv' not in dilberts
         assert 'raj' not in dilberts
         assert 'dan' not in dilberts
@@ -163,7 +163,7 @@ class BloomFilterTests(TestCase):
     def test_repr(self):
         'Test BloomFilter.__repr__()'
         dilberts = BloomFilter(
-            num_values=100,
+            num_elements=100,
             false_positives=0.01,
             key=self._KEY,
         )
@@ -195,7 +195,7 @@ class RecentlyConsumedTests(TestCase):
         # Initialize the recently consumed Bloom filter on the seen set.
         self.recently_consumed = BloomFilter(
             self.seen_links,
-            num_values=1000,
+            num_elements=1000,
             false_positives=0.001,
             key=self._KEY,
         )


### PR DESCRIPTION
`num_elements` is more clear than `num_values`, as in Python-speak,
`value` implies `key`.