### PR TITLE
Don't auto-release Redlock on instance destruction

### DIFF
--- a/pottery/__init__.py
+++ b/pottery/__init__.py
@@ -13,7 +13,7 @@ know how to use Pottery.
 
 
 __title__ = 'pottery'
-__version__ = '1.0.1'
+__version__ = '1.0.2'
 __description__, __long_description__ = (
     s.strip() for s in __doc__.split(sep='\n\n', maxsplit=1)
 )

--- a/pottery/redlock.py
+++ b/pottery/redlock.py
@@ -24,7 +24,6 @@ Lua scripting:
 
 import concurrent.futures
 import contextlib
-import logging
 import os
 import random
 import time
@@ -38,16 +37,12 @@ from redis import Redis
 from redis.client import Script
 from redis.exceptions import ConnectionError
 from redis.exceptions import TimeoutError
-from typing_extensions import Final
 
 from .base import Primitive
 from .exceptions import ExtendUnlockedLock
 from .exceptions import ReleaseUnlockedLock
 from .exceptions import TooManyExtensions
 from .timer import ContextTimer
-
-
-_logger: Final[logging.Logger] = logging.getLogger('pottery')
 
 
 class Redlock(Primitive):
@@ -466,14 +461,6 @@ class Redlock(Primitive):
             [True, False]
         '''
         self.__release()
-
-    def __del__(self) -> None:
-        with contextlib.suppress(ReleaseUnlockedLock):
-            self.__release()
-            _logger.error(
-                'Unlocked %s (instance is about to be destroyed)',
-                self,
-            )
 
     def __repr__(self) -> str:
         return (

--- a/tests/test_redlock.py
+++ b/tests/test_redlock.py
@@ -8,7 +8,6 @@
 
 
 import contextlib
-import gc
 import time
 
 from pottery import ContextTimer
@@ -173,14 +172,6 @@ class RedlockTests(TestCase):
             assert self.redis.exists(self.redlock.key)
             self.redlock.release()
             assert not self.redis.exists(self.redlock.key)
-
-    def test_unlocks_on_del(self):
-        key = self.redlock.key
-        assert self.redlock.acquire()
-        assert self.redis.exists(key)
-        del self.redlock
-        gc.collect()
-        assert not self.redis.exists(key)
 
     def test_repr(self):
         assert repr(self.redlock) == \


### PR DESCRIPTION
This PR effectively reverts this one: https://github.com/brainix/pottery/pull/272

When I deployed this to production, I started seeing these tracebacks in
the logs:

    rajiv.shah@RajivsMacBookPro spool % heroku run python3 manage.py renumber_popularity
    Running python3 manage.py renumber_popularity on ⬢ spool... up, run.4291 (Hobby)
    [2020-11-23 00:46:42,717] INFO in stooges: renumber_popularity() held redlock:popularity for 38 ms
    Exception ignored in: <function Redlock.__del__ at 0x7f5aa68db8b0>
    Traceback (most recent call last):
      File "/app/.heroku/python/lib/python3.9/site-packages/pottery/redlock.py", line 472, in __del__
        self.__release()
      File "/app/.heroku/python/lib/python3.9/site-packages/pottery/redlock.py", line 409, in release
        futures.add(executor.submit(self.__release_master, master))
      File "/app/.heroku/python/lib/python3.9/concurrent/futures/thread.py", line 163, in submit
        raise RuntimeError('cannot schedule new futures after '
    RuntimeError: cannot schedule new futures after interpreter shutdown

On second thought, the Redlock's timeout should be enough to preserve
liveness; we don't need to also auto-release Redlock on instance
destruction.