### PR TITLE
In random_key(), type/value check num_tries

### DIFF
--- a/pottery/base.py
+++ b/pottery/base.py
@@ -50,10 +50,15 @@ def random_key(*,
                redis: Redis,
                prefix: str = 'pottery:',
                length: int = 16,
-               tries: int = 3,
+               num_tries: int = 3,
                ) -> str:
-    if tries <= 0:
+    if not isinstance(num_tries, int):
+        raise TypeError('num_tries must be an int >= 0')
+    elif num_tries < 0:
+        raise ValueError('num_tries must be an int >= 0')
+    elif num_tries <= 0:
         raise RandomKeyError(redis)
+
     all_chars = string.digits + string.ascii_letters
     random_char = functools.partial(random.choice, all_chars)
     suffix = ''.join(cast(str, random_char()) for n in range(length))
@@ -63,7 +68,7 @@ def random_key(*,
             redis=redis,
             prefix=prefix,
             length=length,
-            tries=tries-1,
+            num_tries=num_tries-1,
         )
     return key
 

--- a/pottery/timer.py
+++ b/pottery/timer.py
@@ -17,7 +17,7 @@ class ContextTimer:
     '''Measure the execution time of small code snippets.
 
     Note that ContextTimer measures wall (real-world) time, not CPU time; and
-    that elapsed() returns time in milliseconds.
+    that .elapsed() returns time in milliseconds.
 
     You can use ContextTimer stand-alone...
 

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -10,7 +10,24 @@ import unittest.mock
 
 from pottery import RandomKeyError
 from pottery import RedisDict
+from pottery.base import random_key
 from tests.base import TestCase  # type: ignore
+
+
+class RandomKeyTests(TestCase):
+    def test_random_key_raises_typeerror_for_invalid_num_tries(self):
+        with self.assertRaises(TypeError):
+            random_key(redis=self.redis, num_tries=3.0)
+
+    def test_random_key_raises_valueerror_for_invalid_num_tries(self):
+        with self.assertRaises(ValueError):
+            random_key(redis=self.redis, num_tries=-1)
+
+    def test_random_key_raises_randomkeyerror_when_no_tries_left(self):
+        with self.assertRaises(RandomKeyError), \
+             unittest.mock.patch.object(self.redis, 'exists') as exists:
+            exists.return_value = True
+            random_key(redis=self.redis)
 
 
 class _BaseTestCase(TestCase):


### PR DESCRIPTION
I'm not a fan of `isinstance()` type checks (as opposed to duck typing).
But since `num_tries` establishes the base case for our recursive
function, it's worth coding defensively here.