### PR TITLE
Save Lua scripts as class vars; register them once

### DIFF
--- a/pottery/__init__.py
+++ b/pottery/__init__.py
@@ -13,7 +13,7 @@ know how to use Pottery.
 
 
 __title__ = 'pottery'
-__version__ = '1.0.4'
+__version__ = '1.0.5'
 __description__, __long_description__ = (
     s.strip() for s in __doc__.split(sep='\n\n', maxsplit=1)
 )


### PR DESCRIPTION
Previously, we were saving Lua scripts as instance variables and
re-registering them every time we instantiated a `Redlock` or `NextId`.

I got this pattern from here:
https://github.com/andymccurdy/redis-py/blob/1a41cfd95a53a95b078084d8627be6b6fba3bb71/redis/lock.py#L140-L149