### PR TITLE
Instead of Exception, catch only RedisError

### DIFF
--- a/pottery/__init__.py
+++ b/pottery/__init__.py
@@ -13,7 +13,7 @@ know how to use Pottery.
 
 
 __title__ = 'pottery'
-__version__ = '1.0.5'
+__version__ = '1.0.6'
 __description__, __long_description__ = (
     s.strip() for s in __doc__.split(sep='\n\n', maxsplit=1)
 )

--- a/pottery/nextid.py
+++ b/pottery/nextid.py
@@ -23,6 +23,7 @@ from typing import Optional
 from typing import cast
 
 from redis import Redis
+from redis import RedisError
 from redis.client import Script
 from typing_extensions import Final
 
@@ -138,7 +139,7 @@ class NextId(Primitive):
             for future in concurrent.futures.as_completed(futures):
                 try:
                     current_ids.append(int(future.result()))
-                except Exception as error:
+                except RedisError as error:
                     _logger.error(error, exc_info=True)
         num_masters_gotten = len(current_ids)
         if num_masters_gotten < len(self.masters) // 2 + 1:
@@ -161,7 +162,7 @@ class NextId(Primitive):
             for future in concurrent.futures.as_completed(futures):
                 try:
                     num_masters_set += future.result() == value
-                except Exception as error:
+                except RedisError as error:
                     _logger.error(error, exc_info=True)
         if num_masters_set < len(self.masters) // 2 + 1:
             raise QuorumNotAchieved(self.masters, self.key)

--- a/pottery/redlock.py
+++ b/pottery/redlock.py
@@ -36,6 +36,7 @@ from typing import Type
 from typing import cast
 
 from redis import Redis
+from redis import RedisError
 from redis.client import Script
 from typing_extensions import Final
 
@@ -254,7 +255,7 @@ class Redlock(Primitive):
             for future in concurrent.futures.as_completed(futures):
                 try:
                     num_masters_acquired += future.result()
-                except Exception as error:  # pragma: no cover
+                except RedisError as error:  # pragma: no cover
                     _logger.error(error, exc_info=True)
             quorum = num_masters_acquired >= len(self.masters) // 2 + 1
             elapsed = timer.elapsed() - self.__drift()
@@ -359,7 +360,7 @@ class Redlock(Primitive):
             for future in concurrent.futures.as_completed(futures):
                 try:
                     ttls.append(future.result())
-                except Exception as error:  # pragma: no cover
+                except RedisError as error:  # pragma: no cover
                     _logger.error(error, exc_info=True)
             num_masters_acquired = sum(1 for ttl in ttls if ttl > 0)
             quorum = num_masters_acquired >= len(self.masters) // 2 + 1
@@ -401,7 +402,7 @@ class Redlock(Primitive):
                 for future in concurrent.futures.as_completed(futures):
                     try:
                         num_masters_extended += future.result()
-                    except Exception as error:  # pragma: no cover
+                    except RedisError as error:  # pragma: no cover
                         _logger.error(error, exc_info=True)
             quorum = num_masters_extended >= len(self.masters) // 2 + 1
             self._extension_num += quorum
@@ -431,7 +432,7 @@ class Redlock(Primitive):
             for future in concurrent.futures.as_completed(futures):
                 try:
                     num_masters_released += future.result()
-                except Exception as error:  # pragma: no cover
+                except RedisError as error:  # pragma: no cover
                     _logger.error(error, exc_info=True)
         quorum = num_masters_released >= len(self.masters) // 2 + 1
         if not quorum:


### PR DESCRIPTION
Tighten up and target our `try`/`except` blocks in our distributed
algorithms.  `RedisError` is the base exception class for all exceptions
raised by redis-py.

https://github.com/andymccurdy/redis-py/blob/1a41cfd95a53a95b078084d8627be6b6fba3bb71/redis/exceptions.py#L4-L5