### PR TITLE
When possible, bail out early when quorum achieved

### DIFF
--- a/pottery/executor.py
+++ b/pottery/executor.py
@@ -1,0 +1,15 @@
+# --------------------------------------------------------------------------- #
+#   executor.py                                                               #
+#                                                                             #
+#   Copyright © 2015-2020, Rajiv Bakulesh Shah, original author.              #
+#   All rights reserved.                                                      #
+# --------------------------------------------------------------------------- #
+
+
+import concurrent.futures
+
+
+class BailOutExecutor(concurrent.futures.ThreadPoolExecutor):
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self.shutdown(wait=False)
+        return False

--- a/pottery/redlock.py
+++ b/pottery/redlock.py
@@ -44,6 +44,7 @@ from .base import Primitive
 from .exceptions import ExtendUnlockedLock
 from .exceptions import ReleaseUnlockedLock
 from .exceptions import TooManyExtensions
+from .executor import BailOutExecutor
 from .timer import ContextTimer
 
 
@@ -248,11 +249,13 @@ class Redlock(Primitive):
         self._value = os.urandom(self.num_random_bytes)
         self._extension_num = 0
         quorum, validity_time = False, 0.0
-        with ContextTimer() as timer:
-            executor = concurrent.futures.ThreadPoolExecutor()
-            futures, num_masters_acquired = set(), 0
+
+        with ContextTimer() as timer, BailOutExecutor() as executor:
+            futures = set()
             for master in self.masters:
                 futures.add(executor.submit(self.__acquire_master, master))
+
+            num_masters_acquired = 0
             for future in concurrent.futures.as_completed(futures):
                 try:
                     num_masters_acquired += future.result()
@@ -264,7 +267,7 @@ class Redlock(Primitive):
                         elapsed = timer.elapsed() - self.__drift()
                         validity_time = self.auto_release_time - elapsed
                         break
-            executor.shutdown(wait=False)
+
         if quorum and max(validity_time, 0):
             return True
         else:
@@ -359,14 +362,17 @@ class Redlock(Primitive):
         '''
         with ContextTimer() as timer, \
              concurrent.futures.ThreadPoolExecutor() as executor:
-            futures, ttls = set(), []
+            futures = set()
             for master in self.masters:
                 futures.add(executor.submit(self.__acquired_master, master))
+
+            ttls = []
             for future in concurrent.futures.as_completed(futures):
                 try:
                     ttls.append(future.result())
                 except RedisError as error:  # pragma: no cover
                     _logger.error(error, exc_info=True)
+
             num_masters_acquired = sum(1 for ttl in ttls if ttl > 0)
             quorum = num_masters_acquired >= len(self.masters) // 2 + 1
             if quorum:
@@ -400,20 +406,24 @@ class Redlock(Primitive):
         if self._extension_num >= self.num_extensions:
             raise TooManyExtensions(self.masters, self.key)
         else:
-            executor = concurrent.futures.ThreadPoolExecutor()
-            futures, num_masters_extended, quorum = set(), 0, False
-            for master in self.masters:
-                futures.add(executor.submit(self.__extend_master, master))
-            for future in concurrent.futures.as_completed(futures):
-                try:
-                    num_masters_extended += future.result()
-                except RedisError as error:  # pragma: no cover
-                    _logger.error(error, exc_info=True)
-                else:
-                    quorum = num_masters_extended >= len(self.masters) // 2 + 1
-                    if quorum:
-                        break
-            executor.shutdown(wait=False)
+            quorum = False
+
+            with BailOutExecutor() as executor:
+                futures = set()
+                for master in self.masters:
+                    futures.add(executor.submit(self.__extend_master, master))
+
+                num_masters_extended = 0
+                for future in concurrent.futures.as_completed(futures):
+                    try:
+                        num_masters_extended += future.result()
+                    except RedisError as error:  # pragma: no cover
+                        _logger.error(error, exc_info=True)
+                    else:
+                        quorum = num_masters_extended >= len(self.masters) // 2 + 1
+                        if quorum:
+                            break
+
             self._extension_num += quorum
             if not quorum:
                 raise ExtendUnlockedLock(self.masters, self.key)
@@ -434,20 +444,24 @@ class Redlock(Primitive):
             >>> bool(printer_lock.locked())
             False
         '''
-        executor = concurrent.futures.ThreadPoolExecutor()
-        futures, num_masters_released, quorum = set(), 0, False
-        for master in self.masters:
-            futures.add(executor.submit(self.__release_master, master))
-        for future in concurrent.futures.as_completed(futures):
-            try:
-                num_masters_released += future.result()
-            except RedisError as error:  # pragma: no cover
-                _logger.error(error, exc_info=True)
-            else:
-                quorum = num_masters_released >= len(self.masters) // 2 + 1
-                if quorum:
-                    break
-        executor.shutdown(wait=False)
+        quorum = False
+
+        with BailOutExecutor() as executor:
+            futures = set()
+            for master in self.masters:
+                futures.add(executor.submit(self.__release_master, master))
+
+            num_masters_released = 0
+            for future in concurrent.futures.as_completed(futures):
+                try:
+                    num_masters_released += future.result()
+                except RedisError as error:  # pragma: no cover
+                    _logger.error(error, exc_info=True)
+                else:
+                    quorum = num_masters_released >= len(self.masters) // 2 + 1
+                    if quorum:
+                        break
+
         if not quorum:
             raise ReleaseUnlockedLock(self.masters, self.key)
 


### PR DESCRIPTION
The beating heart of all consensus based distributed algorithms is to
scatter a computation across multiple nodes, then to gather their
results, then to evaluate whether quorum is achieved.

In some cases, _quorum_ requires gathering all of the nodes' results
(e.g., interrogating all nodes for a maximum value for a variable).

But in other cases, _quorum_ requires gathering only `n // 2 + 1` nodes'
results (e.g., figuring out if > 50% of nodes believe that I'm the owner
of a lock).

This commit implements the logic to "bail out" early when possible, in
the latter case.