### PR TITLE
Fix ._scan() bug in RedisCounter._make_counter()

### DIFF
--- a/pottery/__init__.py
+++ b/pottery/__init__.py
@@ -13,7 +13,7 @@ know how to use Pottery.
 
 
 __title__ = 'pottery'
-__version__ = '1.0.7'
+__version__ = '1.0.8'
 __description__, __long_description__ = (
     s.strip() for s in __doc__.split(sep='\n\n', maxsplit=1)
 )

--- a/pottery/counter.py
+++ b/pottery/counter.py
@@ -100,7 +100,7 @@ class RedisCounter(RedisDict, collections.Counter):
             cursor, encoded_dict = self._scan(cursor=cursor)
             decoded_dict = {
                 self._decode(key): self._decode(value)
-                for key, value in self._scan()[1].items()
+                for key, value in encoded_dict.items()
             }
             counter.update(decoded_dict)
             if cursor == 0:  # pragma: no cover


### PR DESCRIPTION
Previously, we were calling `._scan()` multiple times, and using only
every other `._scan()` call's results, and never using `encoded_dict`.

Now, we're using `encoded_dict` and not skippinng over every other
`._scan()` call.