### PR TITLE
In unit tests, explicitly pass in the Redis client

### DIFF
--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -34,13 +34,24 @@ class RandomKeyTests(TestCase):
 class _BaseTestCase(TestCase):
     def setUp(self):
         super().setUp()
-        self.raj = RedisDict(key='pottery:raj', hobby='music', vegetarian=True)
+        self.raj = RedisDict(
+            redis=self.redis,
+            key='pottery:raj',
+            hobby='music',
+            vegetarian=True,
+        )
         self.nilika = RedisDict(
+            redis=self.redis,
             key='pottery:nilika',
             hobby='music',
             vegetarian=True,
         )
-        self.luvh = RedisDict(key='luvh', hobby='bullying', vegetarian=False)
+        self.luvh = RedisDict(
+            redis=self.redis,
+            key='luvh',
+            hobby='bullying',
+            vegetarian=False,
+        )
 
     def tearDown(self):
         self.redis.delete('luvh')
@@ -50,7 +61,7 @@ class _BaseTestCase(TestCase):
 class CommonTests(_BaseTestCase):
     def test_out_of_scope(self):
         def scope():
-            raj = RedisDict(hobby='music', vegetarian=True)
+            raj = RedisDict(redis=self.redis, hobby='music', vegetarian=True)
             assert self.redis.exists(raj.key)
             return raj.key
 

--- a/tests/test_bloom.py
+++ b/tests/test_bloom.py
@@ -19,7 +19,11 @@ class BloomFilterTests(TestCase):
 
     def test_init_without_iterable(self):
         'Test BloomFilter.__init__() without an iterable for initialization'
-        dilberts = BloomFilter(num_elements=100, false_positives=0.01)
+        dilberts = BloomFilter(
+            redis=self.redis,
+            num_elements=100,
+            false_positives=0.01,
+        )
         assert dilberts.num_elements == 100
         assert dilberts.false_positives == 0.01
         assert 'rajiv' not in dilberts
@@ -33,6 +37,7 @@ class BloomFilterTests(TestCase):
         'Test BloomFilter.__init__() with an iterable for initialization'
         dilberts = BloomFilter(
             {'rajiv', 'raj'},
+            redis=self.redis,
             num_elements=100,
             false_positives=0.01,
         )
@@ -51,25 +56,45 @@ class BloomFilterTests(TestCase):
 
     def test_size_and_num_hashes(self):
         'Test BloomFilter.size()'
-        dilberts = BloomFilter(num_elements=100, false_positives=0.1)
+        dilberts = BloomFilter(
+            redis=self.redis,
+            num_elements=100,
+            false_positives=0.1,
+        )
         assert dilberts.size() == 480
         assert dilberts.num_hashes() == 4
 
-        dilberts = BloomFilter(num_elements=1000, false_positives=0.1)
+        dilberts = BloomFilter(
+            redis=self.redis,
+            num_elements=1000,
+            false_positives=0.1,
+        )
         assert dilberts.size() == 4793
         assert dilberts.num_hashes() == 4
 
-        dilberts = BloomFilter(num_elements=100, false_positives=0.01)
+        dilberts = BloomFilter(
+            redis=self.redis,
+            num_elements=100,
+            false_positives=0.01,
+        )
         assert dilberts.size() == 959
         assert dilberts.num_hashes() == 7
 
-        dilberts = BloomFilter(num_elements=1000, false_positives=0.01)
+        dilberts = BloomFilter(
+            redis=self.redis,
+            num_elements=1000,
+            false_positives=0.01,
+        )
         assert dilberts.size() == 9586
         assert dilberts.num_hashes() == 7
 
     def test_add(self):
         'Test BloomFilter add(), __contains__(), and __len__()'
-        dilberts = BloomFilter(num_elements=100, false_positives=0.01)
+        dilberts = BloomFilter(
+            redis=self.redis,
+            num_elements=100,
+            false_positives=0.01,
+        )
         assert 'rajiv' not in dilberts
         assert 'raj' not in dilberts
         assert 'dan' not in dilberts
@@ -120,7 +145,11 @@ class BloomFilterTests(TestCase):
 
     def test_update(self):
         'Test BloomFilter update(), __contains__(), and __len__()'
-        dilberts = BloomFilter(num_elements=100, false_positives=0.01)
+        dilberts = BloomFilter(
+            redis=self.redis,
+            num_elements=100,
+            false_positives=0.01,
+        )
         assert 'rajiv' not in dilberts
         assert 'raj' not in dilberts
         assert 'dan' not in dilberts
@@ -163,9 +192,10 @@ class BloomFilterTests(TestCase):
     def test_repr(self):
         'Test BloomFilter.__repr__()'
         dilberts = BloomFilter(
+            redis=self.redis,
+            key=self._KEY,
             num_elements=100,
             false_positives=0.01,
-            key=self._KEY,
         )
         assert repr(dilberts) == f'<BloomFilter key={self._KEY}>'
 
@@ -195,9 +225,10 @@ class RecentlyConsumedTests(TestCase):
         # Initialize the recently consumed Bloom filter on the seen set.
         self.recently_consumed = BloomFilter(
             self.seen_links,
+            redis=self.redis,
+            key=self._KEY,
             num_elements=1000,
             false_positives=0.001,
-            key=self._KEY,
         )
 
     def tearDown(self):

--- a/tests/test_counter.py
+++ b/tests/test_counter.py
@@ -19,44 +19,44 @@ class CounterTests(TestCase):
     '''
 
     def test_basic_usage(self):
-        c = RedisCounter()
+        c = RedisCounter(redis=self.redis)
         for word in ('red', 'blue', 'red', 'green', 'blue', 'blue'):
             c[word] += 1
         assert c == collections.Counter(blue=3, red=2, green=1)
 
     def test_init(self):
-        c = RedisCounter()
+        c = RedisCounter(redis=self.redis)
         assert c == collections.Counter()
 
     def test_init_with_iterable(self):
-        c = RedisCounter('gallahad')
+        c = RedisCounter('gallahad', redis=self.redis)
         assert c == collections.Counter(a=3, l=2, g=1, h=1, d=1)  # NoQA: E741
 
     def test_init_with_mapping(self):
-        c = RedisCounter({'red': 4, 'blue': 2})
+        c = RedisCounter({'red': 4, 'blue': 2}, redis=self.redis)
         assert c == collections.Counter(red=4, blue=2)
 
     def test_init_with_kwargs(self):
-        c = RedisCounter(cats=4, dogs=8)
+        c = RedisCounter(redis=self.redis, cats=4, dogs=8)
         assert c == collections.Counter(dogs=8, cats=4)
 
     def test_missing_element_doesnt_raise_keyerror(self):
-        c = RedisCounter(('eggs', 'ham'))
+        c = RedisCounter(('eggs', 'ham'), redis=self.redis)
         assert c['bacon'] == 0
 
     def test_setting_0_adds_item(self):
-        c = RedisCounter(('eggs', 'ham'))
+        c = RedisCounter(('eggs', 'ham'), redis=self.redis)
         assert set(c) == {'eggs', 'ham'}
         c['sausage'] = 0
         assert set(c) == {'eggs', 'ham', 'sausage'}
 
     def test_setting_0_count_doesnt_remove_item(self):
-        c = RedisCounter(('eggs', 'ham'))
+        c = RedisCounter(('eggs', 'ham'), redis=self.redis)
         c['ham'] = 0
         assert set(c) == {'eggs', 'ham'}
 
     def test_del_removes_item(self):
-        c = RedisCounter(('eggs', 'ham'))
+        c = RedisCounter(('eggs', 'ham'), redis=self.redis)
         c['sausage'] = 0
         assert set(c) == {'eggs', 'ham', 'sausage'}
         del c['sausage']
@@ -65,35 +65,35 @@ class CounterTests(TestCase):
         assert set(c) == {'eggs'}
 
     def test_elements(self):
-        c = RedisCounter(a=4, b=2, c=0, d=-2)
+        c = RedisCounter(redis=self.redis, a=4, b=2, c=0, d=-2)
         assert sorted(c.elements()) == ['a', 'a', 'a', 'a', 'b', 'b']
 
     def test_most_common(self):
-        c = RedisCounter('abracadabra')
+        c = RedisCounter('abracadabra', redis=self.redis)
         assert sorted(c.most_common(3)) == [('a', 5), ('b', 2), ('r', 2)]
 
     def test_update_with_empty_dict(self):
-        c = RedisCounter(foo=1)
+        c = RedisCounter(redis=self.redis, foo=1)
         c.update({})
         assert isinstance(c, RedisCounter)
         assert c == collections.Counter(foo=1)
 
     def test_update_with_overlapping_dict(self):
-        c = RedisCounter(foo=1, bar=1)
+        c = RedisCounter(redis=self.redis, foo=1, bar=1)
         c.update({'bar': 1, 'baz': 3, 'qux': 4})
         assert isinstance(c, RedisCounter)
         assert c == collections.Counter(foo=1, bar=2, baz=3, qux=4)
 
     def test_subtract(self):
-        c = RedisCounter(a=4, b=2, c=0, d=-2)
-        d = RedisCounter(a=1, b=2, c=3, d=4)
+        c = RedisCounter(redis=self.redis, a=4, b=2, c=0, d=-2)
+        d = RedisCounter(redis=self.redis, a=1, b=2, c=3, d=4)
         c.subtract(d)
         assert isinstance(c, RedisCounter)
         assert c == collections.Counter(a=3, b=0, c=-3, d=-6)
 
     def test_repr(self):
         'Test RedisCounter.__repr__()'
-        c = RedisCounter(('eggs', 'ham'))
+        c = RedisCounter(('eggs', 'ham'), redis=self.redis)
         assert repr(c) in {
             "RedisCounter{'eggs': 1, 'ham': 1}",
             "RedisCounter{'ham': 1, 'eggs': 1}",
@@ -101,66 +101,66 @@ class CounterTests(TestCase):
 
     def test_add(self):
         'Test RedisCounter.__add__()'
-        c = RedisCounter(a=3, b=1)
-        d = RedisCounter(a=1, b=2)
+        c = RedisCounter(redis=self.redis, a=3, b=1)
+        d = RedisCounter(redis=self.redis, a=1, b=2)
         e = c + d
         assert isinstance(e, collections.Counter)
         assert e == collections.Counter(a=4, b=3)
 
     def test_sub(self):
         'Test RedisCounter.__sub__()'
-        c = RedisCounter(a=3, b=1)
-        d = RedisCounter(a=1, b=2)
+        c = RedisCounter(redis=self.redis, a=3, b=1)
+        d = RedisCounter(redis=self.redis, a=1, b=2)
         e = c - d
         assert isinstance(e, collections.Counter)
         assert e == collections.Counter(a=2)
 
     def test_or(self):
         'Test RedisCounter.__or__()'
-        c = RedisCounter(a=3, b=1)
-        d = RedisCounter(a=1, b=2)
+        c = RedisCounter(redis=self.redis, a=3, b=1)
+        d = RedisCounter(redis=self.redis, a=1, b=2)
         e = c | d
         assert isinstance(e, collections.Counter)
         assert e == collections.Counter(a=3, b=2)
 
     def test_and(self):
         'Test RedisCounter.__and__()'
-        c = RedisCounter(a=3, b=1)
-        d = RedisCounter(a=1, b=2)
+        c = RedisCounter(redis=self.redis, a=3, b=1)
+        d = RedisCounter(redis=self.redis, a=1, b=2)
         e = c & d
         assert isinstance(e, collections.Counter)
         assert e == collections.Counter(a=1, b=1)
 
     def test_pos(self):
         'Test RedisCounter.__pos__()'
-        c = RedisCounter(foo=-2, bar=-1, baz=0, qux=1)
+        c = RedisCounter(redis=self.redis, foo=-2, bar=-1, baz=0, qux=1)
         assert isinstance(+c, collections.Counter)
         assert +c == collections.Counter(qux=1)
 
     def test_neg(self):
         'Test RedisCounter.__neg__()'
-        c = RedisCounter(foo=-2, bar=-1, baz=0, qux=1)
+        c = RedisCounter(redis=self.redis, foo=-2, bar=-1, baz=0, qux=1)
         assert isinstance(-c, collections.Counter)
         assert -c == collections.Counter(foo=2, bar=1)
 
     def test_in_place_add_with_empty_counter(self):
         'Test RedisCounter.__iadd__() with an empty counter'
-        c = RedisCounter(a=1, b=2)
-        d = RedisCounter()
+        c = RedisCounter(redis=self.redis, a=1, b=2)
+        d = RedisCounter(redis=self.redis)
         c += d
         assert isinstance(c, RedisCounter)
         assert c == collections.Counter(a=1, b=2)
 
     def test_in_place_add_with_overlapping_counter(self):
         'Test RedisCounter.__iadd__() with a counter with overlapping keys'
-        c = RedisCounter(a=4, b=2, c=0, d=-2)
-        d = RedisCounter(a=1, b=2, c=3, d=4)
+        c = RedisCounter(redis=self.redis, a=4, b=2, c=0, d=-2)
+        d = RedisCounter(redis=self.redis, a=1, b=2, c=3, d=4)
         c += d
         assert isinstance(c, RedisCounter)
         assert c == collections.Counter(a=5, b=4, c=3, d=2)
 
     def test_in_place_add_removes_zeroes(self):
-        c = RedisCounter(a=4, b=2, c=0, d=-2)
+        c = RedisCounter(redis=self.redis, a=4, b=2, c=0, d=-2)
         d = collections.Counter(a=-4, b=-2, c=0, d=2)
         c += d
         assert isinstance(c, RedisCounter)
@@ -168,23 +168,23 @@ class CounterTests(TestCase):
 
     def test_in_place_subtract(self):
         'Test RedisCounter.__isub__()'
-        c = RedisCounter(a=4, b=2, c=0, d=-2)
-        d = RedisCounter(a=1, b=2, c=3, d=4)
+        c = RedisCounter(redis=self.redis, a=4, b=2, c=0, d=-2)
+        d = RedisCounter(redis=self.redis, a=1, b=2, c=3, d=4)
         c -= d
         assert isinstance(c, RedisCounter)
         assert c == collections.Counter(a=3)
 
     def test_in_place_or_with_two_empty_counters(self):
         'Test RedisCounter.__ior__() with two empty counters'
-        c = RedisCounter()
-        d = RedisCounter()
+        c = RedisCounter(redis=self.redis)
+        d = RedisCounter(redis=self.redis)
         c |= d
         assert isinstance(c, RedisCounter)
         assert c == collections.Counter()
 
     def test_in_place_or_with_two_overlapping_counters(self):
         'Test RedisCounter.__ior__() with two counters with overlapping keys'
-        c = RedisCounter(a=4, b=2, c=0, d=-2)
+        c = RedisCounter(redis=self.redis, a=4, b=2, c=0, d=-2)
         d = collections.Counter(a=1, b=2, c=3, d=4)
         c |= d
         assert isinstance(c, RedisCounter)
@@ -192,15 +192,15 @@ class CounterTests(TestCase):
 
     def test_in_place_and(self):
         'Test RedisCounter.__iand__()'
-        c = RedisCounter(a=4, b=2, c=0, d=-2)
-        d = RedisCounter(a=1, b=2, c=3, d=4)
+        c = RedisCounter(redis=self.redis, a=4, b=2, c=0, d=-2)
+        d = RedisCounter(redis=self.redis, a=1, b=2, c=3, d=4)
         c &= d
         assert isinstance(c, RedisCounter)
         assert c == collections.Counter(a=1, b=2)
 
     def test_in_place_and_results_in_empty_counter(self):
-        c = RedisCounter(a=4, b=2)
-        d = RedisCounter(c=3, d=4)
+        c = RedisCounter(redis=self.redis, a=4, b=2)
+        d = RedisCounter(redis=self.redis, c=3, d=4)
         c &= d
         assert isinstance(c, RedisCounter)
         assert c == collections.Counter()

--- a/tests/test_deque.py
+++ b/tests/test_deque.py
@@ -19,7 +19,7 @@ class DequeTests(TestCase):
     '''
 
     def test_basic_usage(self):
-        d = RedisDeque('ghi')
+        d = RedisDeque('ghi', redis=self.redis)
         assert d == ['g', 'h', 'i']
 
         d.append('j')
@@ -41,7 +41,7 @@ class DequeTests(TestCase):
         d.rotate(-1)
         assert d == ['g', 'h', 'i', 'j', 'k', 'l']
 
-        assert RedisDeque(reversed(d)) == ['l', 'k', 'j', 'i', 'h', 'g']
+        assert RedisDeque(reversed(d), redis=self.redis) == ['l', 'k', 'j', 'i', 'h', 'g']
         d.clear()
         with self.assertRaises(IndexError):
             d.pop()
@@ -53,21 +53,21 @@ class DequeTests(TestCase):
         with unittest.mock.patch.object(Base, '__del__') as delete, \
              self.assertRaises(TypeError):
             delete.return_value = None
-            RedisDeque(maxlen='2')
+            RedisDeque(redis=self.redis, maxlen='2')
 
     def test_persistent_deque_bigger_than_maxlen(self):
-        d1 = RedisDeque('ghi')
+        d1 = RedisDeque('ghi', redis=self.redis)
         d1  # Workaround for Pyflakes.  :-(
         with self.assertRaises(IndexError):
-            RedisDeque(key=d1.key, maxlen=0)
+            RedisDeque(redis=self.redis, key=d1.key, maxlen=0)
 
     def test_maxlen_not_writable(self):
-        d = RedisDeque()
+        d = RedisDeque(redis=self.redis)
         with self.assertRaises(AttributeError):
             d.maxlen = 2
 
     def test_insert_into_full(self):
-        d = RedisDeque('gh', maxlen=3)
+        d = RedisDeque('gh', redis=self.redis, maxlen=3)
         d.insert(len(d), 'i')
         assert d == ['g', 'h', 'i']
 
@@ -75,7 +75,7 @@ class DequeTests(TestCase):
             d.insert(len(d), 'j')
 
     def test_append_trims_when_full(self):
-        d = RedisDeque('gh', maxlen=3)
+        d = RedisDeque('gh', redis=self.redis, maxlen=3)
         d.append('i')
         assert d == ['g', 'h', 'i']
         d.append('j')
@@ -84,31 +84,31 @@ class DequeTests(TestCase):
         assert d == ['g', 'h', 'i']
 
     def test_extend(self):
-        d = RedisDeque('ghi', maxlen=4)
+        d = RedisDeque('ghi', redis=self.redis, maxlen=4)
         d.extend('jkl')
         assert d == ['i', 'j', 'k', 'l']
         d.extendleft('hg')
         assert d == ['g', 'h', 'i', 'j']
 
     def test_popleft_from_empty(self):
-        d = RedisDeque()
+        d = RedisDeque(redis=self.redis)
         with self.assertRaises(IndexError):
             d.popleft()
 
     def test_rotate_zero_steps(self):
-        d = RedisDeque(('g', 'h', 'i', 'j', 'k', 'l'))
+        d = RedisDeque(('g', 'h', 'i', 'j', 'k', 'l'), redis=self.redis)
         d.rotate(0)
         assert d == ['g', 'h', 'i', 'j', 'k', 'l']
 
     def test_repr(self):
-        d = RedisDeque()
+        d = RedisDeque(redis=self.redis)
         assert repr(d) == 'RedisDeque([])'
 
-        d = RedisDeque('ghi')
+        d = RedisDeque('ghi', redis=self.redis)
         assert repr(d) == "RedisDeque(['g', 'h', 'i'])"
 
-        d = RedisDeque(maxlen=2)
+        d = RedisDeque(redis=self.redis, maxlen=2)
         assert repr(d) == 'RedisDeque([], maxlen=2)'
 
-        d = RedisDeque('ghi', maxlen=2)
+        d = RedisDeque('ghi', redis=self.redis, maxlen=2)
         assert repr(d) == "RedisDeque(['h', 'i'], maxlen=2)"

--- a/tests/test_dict.py
+++ b/tests/test_dict.py
@@ -20,16 +20,40 @@ class DictTests(TestCase):
     '''
 
     def test_keyexistserror_raised(self):
-        d = RedisDict(key='pottery:tel', sape=4139, guido=4127, jack=4098)
+        d = RedisDict(
+            redis=self.redis,
+            key='pottery:tel',
+            sape=4139,
+            guido=4127,
+            jack=4098,
+        )
         d   # Workaround for Pyflakes.  :-(
         with self.assertRaises(KeyExistsError):
-            RedisDict(key='pottery:tel', sape=4139, guido=4127, jack=4098)
+            RedisDict(
+                redis=self.redis,
+                key='pottery:tel',
+                sape=4139,
+                guido=4127,
+                jack=4098,
+            )
 
     def test_keyexistserror_repr(self):
-        d = RedisDict(key='pottery:tel', sape=4139, guido=4127, jack=4098)
+        d = RedisDict(
+            redis=self.redis,
+            key='pottery:tel',
+            sape=4139,
+            guido=4127,
+            jack=4098,
+        )
         d   # Workaround for Pyflakes.  :-(
         try:
-            RedisDict(key='pottery:tel', sape=4139, guido=4127, jack=4098)
+            RedisDict(
+                redis=self.redis,
+                key='pottery:tel',
+                sape=4139,
+                guido=4127,
+                jack=4098,
+            )
         except KeyExistsError as wtf:
             assert repr(wtf) == (
                 "KeyExistsError(redis=Redis<ConnectionPool<Connection<host=localhost,port=6379,db=0>>>, "
@@ -39,10 +63,22 @@ class DictTests(TestCase):
             self.fail(msg='KeyExistsError not raised')
 
     def test_keyexistserror_str(self):
-        d = RedisDict(key='pottery:tel', sape=4139, guido=4127, jack=4098)
+        d = RedisDict(
+            redis=self.redis,
+            key='pottery:tel',
+            sape=4139,
+            guido=4127,
+            jack=4098,
+        )
         d   # Workaround for Pyflakes.  :-(
         try:
-            RedisDict(key='pottery:tel', sape=4139, guido=4127, jack=4098)
+            RedisDict(
+                redis=self.redis,
+                key='pottery:tel',
+                sape=4139,
+                guido=4127,
+                jack=4098,
+            )
         except KeyExistsError as wtf:
             assert str(wtf) == (
                 "redis=Redis<ConnectionPool<Connection<host=localhost,port=6379,db=0>>> "
@@ -52,7 +88,7 @@ class DictTests(TestCase):
             self.fail(msg='KeyExistsError not raised')
 
     def test_basic_usage(self):
-        tel = RedisDict(jack=4098, sape=4139)
+        tel = RedisDict(redis=self.redis, jack=4098, sape=4139)
         tel['guido'] = 4127
         assert tel == {'sape': 4139, 'guido': 4127, 'jack': 4098}
         assert tel['jack'] == 4098
@@ -64,28 +100,31 @@ class DictTests(TestCase):
         assert not 'jack' not in tel
 
     def test_init_with_key_value_pairs(self):
-        d = RedisDict([('sape', 4139), ('guido', 4127), ('jack', 4098)])
+        d = RedisDict(
+            [('sape', 4139), ('guido', 4127), ('jack', 4098)],
+            redis=self.redis,
+        )
         assert d == {'sape': 4139, 'jack': 4098, 'guido': 4127}
 
     def test_init_with_kwargs(self):
-        d = RedisDict(sape=4139, guido=4127, jack=4098)
+        d = RedisDict(redis=self.redis, sape=4139, guido=4127, jack=4098)
         assert d == {'sape': 4139, 'jack': 4098, 'guido': 4127}
 
     # The following tests come from these examples:
     #   https://docs.python.org/3.4/library/stdtypes.html#mapping-types-dict
 
     def test_more_construction_options(self):
-        a = RedisDict(one=1, two=2, three=3)
+        a = RedisDict(redis=self.redis, one=1, two=2, three=3)
         b = {'one': 1, 'two': 2, 'three': 3}
-        c = RedisDict(zip(['one', 'two', 'three'], [1, 2, 3]))
-        d = RedisDict([('two', 2), ('one', 1), ('three', 3)])
-        e = RedisDict({'three': 3, 'one': 1, 'two': 2})
+        c = RedisDict(zip(['one', 'two', 'three'], [1, 2, 3]), redis=self.redis)
+        d = RedisDict([('two', 2), ('one', 1), ('three', 3)], redis=self.redis)
+        e = RedisDict({'three': 3, 'one': 1, 'two': 2}, redis=self.redis)
         assert a == b == c == d == e
 
     def test_len(self):
-        a = RedisDict()
+        a = RedisDict(redis=self.redis)
         assert len(a) == 0
-        a = RedisDict(one=1, two=2, three=3)
+        a = RedisDict(redis=self.redis, one=1, two=2, three=3)
         assert len(a) == 3
         a['four'] = 4
         assert len(a) == 4
@@ -93,14 +132,14 @@ class DictTests(TestCase):
         assert len(a) == 3
 
     def test_repr(self):
-        a = RedisDict(one=1, two=2)
+        a = RedisDict(redis=self.redis, one=1, two=2)
         assert repr(a) in {
             "RedisDict{'one': 1, 'two': 2}",
             "RedisDict{'two': 2, 'one': 1}",
         }
 
     def test_update(self):
-        a = RedisDict(one=1, two=2, three=3)
+        a = RedisDict(redis=self.redis, one=1, two=2, three=3)
         a.update()
         assert a == {'one': 1, 'two': 2, 'three': 3}
 
@@ -132,7 +171,7 @@ class DictTests(TestCase):
         }
 
     def test_keyerror(self):
-        a = RedisDict(one=1, two=2, three=3)
+        a = RedisDict(redis=self.redis, one=1, two=2, three=3)
         assert a['one'] == 1
         assert a['two'] == 2
         assert a['three'] == 3
@@ -140,7 +179,7 @@ class DictTests(TestCase):
             a['four']
 
     def test_key_assignment(self):
-        a = RedisDict(one=1, two=2, three=2)
+        a = RedisDict(redis=self.redis, one=1, two=2, three=2)
         assert a['three'] == 2
         a['three'] = 3
         assert a['three'] == 3
@@ -148,7 +187,7 @@ class DictTests(TestCase):
         assert a['four'] == 4
 
     def test_key_deletion(self):
-        a = RedisDict(one=1, two=2, three=3)
+        a = RedisDict(redis=self.redis, one=1, two=2, three=3)
         assert sorted(a) == ['one', 'three', 'two']
         a['four'] = 4
         assert sorted(a) == ['four', 'one', 'three', 'two']
@@ -166,7 +205,7 @@ class DictTests(TestCase):
             del a['one']
 
     def test_key_membership(self):
-        a = RedisDict(one=1, two=2, three=3)
+        a = RedisDict(redis=self.redis, one=1, two=2, three=3)
         assert 'one' in a
         assert 'four' not in a
         assert not 'four' in a
@@ -177,7 +216,7 @@ class DictTests(TestCase):
         assert not 'four' in a
 
     def test_clear(self):
-        a = RedisDict(one=1, two=2, three=3)
+        a = RedisDict(redis=self.redis, one=1, two=2, three=3)
         assert sorted(a) == ['one', 'three', 'two']
         assert a.clear() is None
         assert sorted(a) == []
@@ -185,7 +224,7 @@ class DictTests(TestCase):
         assert sorted(a) == []
 
     def test_get(self):
-        a = RedisDict(one=1, two=2, three=3)
+        a = RedisDict(redis=self.redis, one=1, two=2, three=3)
         assert a.get('one') == 1
         assert a.get('one', 42) == 1
         assert a.get('two') == 2
@@ -202,7 +241,7 @@ class DictTests(TestCase):
         assert a.get('four', 42) == 42
 
     def test_items(self):
-        a = RedisDict(one=1, two=2, three=3)
+        a = RedisDict(redis=self.redis, one=1, two=2, three=3)
         assert isinstance(a.items(), collections.abc.ItemsView)
         assert len(a) == 3
         assert set(a.items()) == {('one', 1), ('two', 2), ('three', 3)}
@@ -210,7 +249,7 @@ class DictTests(TestCase):
         assert ('four', 4) not in a.items()
 
     def test_keys(self):
-        a = RedisDict(one=1, two=2, three=3)
+        a = RedisDict(redis=self.redis, one=1, two=2, three=3)
         assert isinstance(a.keys(), collections.abc.KeysView)
         assert len(a) == 3
         assert set(a.keys()) == {'one', 'two', 'three'}
@@ -218,7 +257,7 @@ class DictTests(TestCase):
         assert 'four' not in a.keys()
 
     def test_values(self):
-        a = RedisDict(one=1, two=2, three=3)
+        a = RedisDict(redis=self.redis, one=1, two=2, three=3)
         assert isinstance(a.values(), collections.abc.ValuesView)
         assert len(a) == 3
         assert set(a.values()) == {1, 2, 3}
@@ -226,9 +265,9 @@ class DictTests(TestCase):
         assert 4 not in a.values()
 
     def test_membership_for_non_jsonifyable_element(self):
-        redis_dict = RedisDict()
+        redis_dict = RedisDict(redis=self.redis)
         assert not BaseException in redis_dict
 
     def test_json_dumps(self):
-        a = RedisDict(one=1, two=2, three=3)
+        a = RedisDict(redis=self.redis, one=1, two=2, three=3)
         assert json.dumps(a) == '{"one": 1, "two": 2, "three": 3}'

--- a/tests/test_hyper.py
+++ b/tests/test_hyper.py
@@ -14,15 +14,15 @@ class HyperLogLogTests(TestCase):
     _KEY = f'{TestCase._TEST_KEY_PREFIX}hll'
 
     def test_init_without_iterable(self):
-        hll = HyperLogLog()
+        hll = HyperLogLog(redis=self.redis)
         assert len(hll) == 0
 
     def test_init_with_iterable(self):
-        hll = HyperLogLog({'foo', 'bar', 'zap', 'a'})
+        hll = HyperLogLog({'foo', 'bar', 'zap', 'a'}, redis=self.redis)
         assert len(hll) == 4
 
     def test_add(self):
-        hll = HyperLogLog()
+        hll = HyperLogLog(redis=self.redis)
         hll.add('foo')
         assert len(hll) == 1
 
@@ -48,27 +48,31 @@ class HyperLogLogTests(TestCase):
         assert len(hll) == 6
 
     def test_update(self):
-        hll1 = HyperLogLog({'foo', 'bar', 'zap', 'a'})
-        hll2 = HyperLogLog({'a', 'b', 'c', 'foo'})
+        hll1 = HyperLogLog({'foo', 'bar', 'zap', 'a'}, redis=self.redis)
+        hll2 = HyperLogLog({'a', 'b', 'c', 'foo'}, redis=self.redis)
         hll1.update(hll2)
         assert len(hll1) == 6
 
-        hll1 = HyperLogLog({'foo', 'bar', 'zap', 'a'})
+        hll1 = HyperLogLog({'foo', 'bar', 'zap', 'a'}, redis=self.redis)
         hll1.update({'b', 'c', 'd', 'foo'})
         assert len(hll1) == 7
 
-        hll1 = HyperLogLog({'foo', 'bar', 'zap', 'a'})
+        hll1 = HyperLogLog({'foo', 'bar', 'zap', 'a'}, redis=self.redis)
         hll1.update(hll2, {'b', 'c', 'd', 'baz'})
         assert len(hll1) == 8
 
     def test_union(self):
-        hll1 = HyperLogLog({'foo', 'bar', 'zap', 'a'})
-        hll2 = HyperLogLog({'a', 'b', 'c', 'foo'})
+        hll1 = HyperLogLog({'foo', 'bar', 'zap', 'a'}, redis=self.redis)
+        hll2 = HyperLogLog({'a', 'b', 'c', 'foo'}, redis=self.redis)
         assert len(hll1.union(hll2)) == 6
         assert len(hll1.union({'b', 'c', 'd', 'foo'})) == 7
         assert len(hll1.union(hll2, {'b', 'c', 'd', 'baz'})) == 8
 
     def test_repr(self):
         'Test HyperLogLog.__repr__()'
-        hll = HyperLogLog({'foo', 'bar', 'zap', 'a'}, key=self._KEY)
+        hll = HyperLogLog(
+            {'foo', 'bar', 'zap', 'a'},
+            redis=self.redis,
+            key=self._KEY,
+        )
         assert repr(hll) == f'<HyperLogLog key={self._KEY} len=4>'

--- a/tests/test_nextid.py
+++ b/tests/test_nextid.py
@@ -22,7 +22,7 @@ class NextIdTests(TestCase):
     def setUp(self):
         super().setUp()
         self.redis.delete('nextid:current')
-        self.ids = NextId()
+        self.ids = NextId(masters={self.redis})
         for master in self.ids.masters:
             master.set(self.ids.key, 0)
 

--- a/tests/test_set.py
+++ b/tests/test_set.py
@@ -19,46 +19,44 @@ class SetTests(TestCase):
     '''
 
     def test_init(self):
-        set_ = RedisSet()
+        set_ = RedisSet(redis=self.redis)
         assert set_ == set()
 
     def test_keyexistserror(self):
         fruits = {'apple', 'orange', 'apple', 'pear', 'orange', 'banana'}
-        basket = RedisSet(fruits, key='pottery:basket')
+        basket = RedisSet(fruits, redis=self.redis, key='pottery:basket')
         basket  # Workaround for Pyflakes.  :-(
         with self.assertRaises(KeyExistsError):
-            RedisSet(fruits, key='pottery:basket')
+            RedisSet(fruits, redis=self.redis, key='pottery:basket')
 
     def test_basic_usage(self):
         fruits = {'apple', 'orange', 'apple', 'pear', 'orange', 'banana'}
-        basket = RedisSet(fruits)
+        basket = RedisSet(fruits, redis=self.redis)
         assert basket == {'orange', 'banana', 'pear', 'apple'}
         assert 'orange' in basket
         assert not 'crabgrass' in basket
 
     def test_add(self):
-        basket = RedisSet({
-            'apple', 'orange', 'apple', 'pear', 'orange', 'banana',
-        })
+        fruits = {'apple', 'orange', 'apple', 'pear', 'orange', 'banana'}
+        basket = RedisSet(fruits, redis=self.redis)
         basket.add('tomato')
         assert basket == {
             'apple', 'orange', 'apple', 'pear', 'orange', 'banana', 'tomato',
         }
 
     def test_discard(self):
-        basket = RedisSet({
-            'apple', 'orange', 'apple', 'pear', 'orange', 'banana', 'tomato',
-        })
+        fruits = {'apple', 'orange', 'apple', 'pear', 'orange', 'banana', 'tomato'}
+        basket = RedisSet(fruits, redis=self.redis)
         basket.discard('tomato')
         assert basket == {
             'apple', 'orange', 'apple', 'pear', 'orange', 'banana',
         }
 
     def test_repr(self):
-        basket = RedisSet({'apple'})
+        basket = RedisSet({'apple'}, redis=self.redis)
         assert repr(basket) == "RedisSet{'apple'}"
 
-        basket = RedisSet({'apple', 'orange'})
+        basket = RedisSet({'apple', 'orange'}, redis=self.redis)
         assert repr(basket) in {
             "RedisSet{'apple', 'orange'}",
             "RedisSet{'orange', 'apple'}",
@@ -66,7 +64,7 @@ class SetTests(TestCase):
 
     def test_pop(self):
         fruits = {'apple', 'orange', 'apple', 'pear', 'orange', 'banana'}
-        basket = RedisSet(fruits)
+        basket = RedisSet(fruits, redis=self.redis)
         for _ in range(len(fruits)):
             fruit = basket.pop()
             assert fruit in fruits
@@ -78,7 +76,7 @@ class SetTests(TestCase):
             basket.pop()
 
     def test_remove(self):
-        basket = RedisSet({'apple', 'orange'})
+        basket = RedisSet({'apple', 'orange'}, redis=self.redis)
         basket.remove('orange')
         assert basket == {'apple'}
 
@@ -89,8 +87,8 @@ class SetTests(TestCase):
             basket.remove('apple')
 
     def test_set_operations(self):
-        a = RedisSet('abracadabra')
-        b = RedisSet('alacazam')
+        a = RedisSet('abracadabra', redis=self.redis)
+        b = RedisSet('alacazam', redis=self.redis)
         assert a == {'a', 'r', 'b', 'c', 'd'}
         assert a - b == {'r', 'd', 'b'}
         assert isinstance(a - b, RedisSet)
@@ -102,10 +100,10 @@ class SetTests(TestCase):
         assert isinstance(a ^ b, RedisSet)
 
     def test_isdisjoint(self):
-        a = RedisSet('abc')
-        b = RedisSet('cde')
+        a = RedisSet('abc', redis=self.redis)
+        b = RedisSet('cde', redis=self.redis)
         assert not a.isdisjoint(b)
-        c = RedisSet('def')
+        c = RedisSet('def', redis=self.redis)
         assert a.isdisjoint(c)
 
         other_url = 'redis://127.0.0.1:6379/'
@@ -121,22 +119,22 @@ class SetTests(TestCase):
         assert a.isdisjoint(e)
 
     def test_issubset(self):
-        a = RedisSet('abc')
-        b = RedisSet('abc')
+        a = RedisSet('abc', redis=self.redis)
+        b = RedisSet('abc', redis=self.redis)
         # assert a.issubset(b)
         # assert b.issubset(a)
         assert a <= b
         assert b <= a
         assert not a < b
         assert not b < a
-        c = RedisSet('abcd')
+        c = RedisSet('abcd', redis=self.redis)
         # assert a.issubset(c)
         # assert not c.issubset(a)
         assert a <= c
         assert not c <= a
         assert a < c
         assert not c < a
-        d = RedisSet('def')
+        d = RedisSet('def', redis=self.redis)
         # assert not a.issubset(d)
         # assert not d.issubset(a)
         assert not a <= d
@@ -145,22 +143,22 @@ class SetTests(TestCase):
         assert not d < a
 
     def test_issuperset(self):
-        a = RedisSet('abc')
-        b = RedisSet('abc')
+        a = RedisSet('abc', redis=self.redis)
+        b = RedisSet('abc', redis=self.redis)
         # assert a.issuperset(b)
         # assert b.issuperset(a)
         assert a >= b
         assert b >= a
         assert not a > b
         assert not b > a
-        c = RedisSet('abcd')
+        c = RedisSet('abcd', redis=self.redis)
         # assert not a.issuperset(c)
         # assert c.issuperset(a)
         assert not a >= c
         assert c >= a
         assert not a > c
         assert c > a
-        d = RedisSet('def')
+        d = RedisSet('def', redis=self.redis)
         # assert not a.issuperset(d)
         # assert not d.issuperset(a)
         assert not a >= d
@@ -169,78 +167,81 @@ class SetTests(TestCase):
         assert not d > a
 
     def test_update_with_no_arguments(self):
-        s = RedisSet()
+        s = RedisSet(redis=self.redis)
         s.update()
         assert s == set()
 
-        s = RedisSet('abcd')
+        s = RedisSet('abcd', redis=self.redis)
         s.update()
         assert s == {'a', 'b', 'c', 'd'}
 
     def test_update_with_empty_set(self):
-        metasyntactic_variables = RedisSet()
+        metasyntactic_variables = RedisSet(redis=self.redis)
         metasyntactic_variables.update(set())
         assert metasyntactic_variables == set()
 
-        metasyntactic_variables = RedisSet({'foo', 'bar', 'baz'})
+        metasyntactic_variables = RedisSet(
+            {'foo', 'bar', 'baz'},
+            redis=self.redis,
+        )
         metasyntactic_variables.update(set())
         assert metasyntactic_variables == {'foo', 'bar', 'baz'}
 
     def test_update_with_set(self):
-        metasyntactic_variables = RedisSet()
+        metasyntactic_variables = RedisSet(redis=self.redis)
         metasyntactic_variables.update({'foo', 'bar', 'baz'})
         assert metasyntactic_variables == {'foo', 'bar', 'baz'}
         metasyntactic_variables.update({'qux'})
         assert metasyntactic_variables == {'foo', 'bar', 'baz', 'qux'}
 
     def test_update_with_range(self):
-        ramanujans_friends = RedisSet()
+        ramanujans_friends = RedisSet(redis=self.redis)
         ramanujans_friends.update(range(10))
         assert ramanujans_friends == {0, 1, 2, 3, 4, 5, 6, 7, 8, 9}
 
     def test_update_with_set_and_range(self):
-        silliness = RedisSet()
+        silliness = RedisSet(redis=self.redis)
         silliness.update({'foo', 'bar', 'baz'}, range(5))
         assert silliness == {'foo', 'bar', 'baz', 0, 1, 2, 3, 4}
         silliness.update({'qux'}, range(6))
         assert silliness == {'foo', 'bar', 'baz', 'qux', 0, 1, 2, 3, 4, 5}
 
     def test_difference_update_with_empty_set(self):
-        ramanujans_friends = RedisSet()
+        ramanujans_friends = RedisSet(redis=self.redis)
         ramanujans_friends.difference_update(set())
         assert ramanujans_friends == set()
 
-        ramanujans_friends = RedisSet(range(10))
+        ramanujans_friends = RedisSet(range(10), redis=self.redis)
         ramanujans_friends.difference_update(set())
         assert ramanujans_friends == {0, 1, 2, 3, 4, 5, 6, 7, 8, 9}
 
     def test_difference_update_with_set(self):
-        ramanujans_friends = RedisSet()
+        ramanujans_friends = RedisSet(redis=self.redis)
         ramanujans_friends.difference_update({5, 6, 7, 8, 9})
         assert ramanujans_friends == set()
 
-        ramanujans_friends = RedisSet(range(10))
+        ramanujans_friends = RedisSet(range(10), redis=self.redis)
         ramanujans_friends.difference_update({5, 6, 7, 8, 9})
         assert ramanujans_friends == {0, 1, 2, 3, 4}
 
     def test_difference_update_with_range(self):
-        ramanujans_friends = RedisSet()
+        ramanujans_friends = RedisSet(redis=self.redis)
         ramanujans_friends.difference_update(range(5))
         assert ramanujans_friends == set()
 
-        ramanujans_friends = RedisSet(range(10))
+        ramanujans_friends = RedisSet(range(10), redis=self.redis)
         ramanujans_friends.difference_update(range(5))
         assert ramanujans_friends == {5, 6, 7, 8, 9}
 
     def test_difference_update_with_range_and_set(self):
-        ramanujans_friends = RedisSet()
+        ramanujans_friends = RedisSet(redis=self.redis)
         ramanujans_friends.difference_update(range(4), {6, 7, 8, 9})
         assert ramanujans_friends == set()
 
-        ramanujans_friends = RedisSet(range(10))
+        ramanujans_friends = RedisSet(range(10), redis=self.redis)
         ramanujans_friends.difference_update(range(4), {6, 7, 8, 9})
         assert ramanujans_friends == {4, 5}
 
     def test_membership_for_non_jsonifyable_element(self):
-        redis_set = RedisSet()
+        redis_set = RedisSet(redis=self.redis)
         assert not BaseException in redis_set


### PR DESCRIPTION
This is the first step toward using a separate Redis database for unit
tests, for easier cleanup.