### PR TITLE
Include typing_extensions in install_requires

### DIFF
--- a/pottery/__init__.py
+++ b/pottery/__init__.py
@@ -13,7 +13,7 @@ know how to use Pottery.
 
 
 __title__ = 'pottery'
-__version__ = '1.0.8'
+__version__ = '1.0.9'
 __description__, __long_description__ = (
     s.strip() for s in __doc__.split(sep='\n\n', maxsplit=1)
 )

--- a/requirements-to-freeze.txt
+++ b/requirements-to-freeze.txt
@@ -11,6 +11,7 @@
 #   https://github.com/andymccurdy/redis-py/issues/1278
 redis>=3.4.1
 mmh3
+typing_extensions
 
 coverage
 coveralls

--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ setup(
     ],
     keywords=pottery.__keywords__,
     packages=find_packages(exclude=('contrib', 'docs', 'tests*')),
-    install_requires=('redis>=3.4.1', 'mmh3'),
+    install_requires=('redis>=3.4.1', 'mmh3', 'typing_extensions'),
     extras_require={},
     package_data={'pottery': ('py.typed',)},
     data_files=tuple(),


### PR DESCRIPTION
Without making Pottery depend on `typing_extensions`, Pottery fails to
install correctly.

Bug first reported here: https://github.com/brainix/pottery/issues/299

I used this as an example: https://github.com/tensorflow/tensorflow/blob/4a8d9cf405e5be8cf250f7fa141f2013f395b5fe/tensorflow/tools/pip_package/setup.py#L89

Thanks, @skieffer, for suggesting this fix.