### PR TITLE
Choose a random Redis database for unit tests

### DIFF
--- a/tests/base.py
+++ b/tests/base.py
@@ -8,13 +8,13 @@
 
 import doctest
 import logging
+import random
 import sys
 import unittest
 from typing import ClassVar
 from typing import NoReturn
 
-from pottery.base import Base
-from pottery.base import _default_redis
+from redis import Redis
 
 
 class TestCase(unittest.TestCase):
@@ -27,17 +27,13 @@ class TestCase(unittest.TestCase):
 
     def setUp(self) -> None:
         super().setUp()
-        self.redis = _default_redis
+        self.redis_db = random.randint(1, 15)
+        url = f'redis://localhost:6379/{self.redis_db}'
+        self.redis = Redis.from_url(url, socket_timeout=1)
+        self.redis.flushdb()
 
     def tearDown(self) -> None:
-        keys_to_delete = []
-        for prefix in {Base._RANDOM_KEY_PREFIX, self._TEST_KEY_PREFIX}:
-            pattern = prefix + '*'
-            keys = self.redis.keys(pattern=pattern)
-            keys = (key.decode('utf-8') for key in keys)
-            keys_to_delete.extend(keys)
-        if keys_to_delete:
-            self.redis.delete(*keys_to_delete)
+        self.redis.flushdb()
         super().tearDown()
 
 

--- a/tests/base.py
+++ b/tests/base.py
@@ -11,15 +11,12 @@ import logging
 import random
 import sys
 import unittest
-from typing import ClassVar
 from typing import NoReturn
 
 from redis import Redis
 
 
 class TestCase(unittest.TestCase):
-    _TEST_KEY_PREFIX: ClassVar[str] = 'pottery-test:'
-
     @classmethod
     def setUpClass(cls) -> None:
         logger = logging.getLogger('pottery')

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -108,7 +108,7 @@ class CommonTests(_BaseTestCase):
             try:
                 self.raj._random_key()
             except RandomKeyError as wtf:
-                assert repr(wtf) == 'RandomKeyError(redis=Redis<ConnectionPool<Connection<host=localhost,port=6379,db=0>>>)'
+                assert repr(wtf) == f'RandomKeyError(redis=Redis<ConnectionPool<Connection<host=localhost,port=6379,db={self.redis_db}>>>)'
             else:  # pragma: no cover
                 self.fail(msg='RandomKeyError not raised')
 
@@ -118,7 +118,7 @@ class CommonTests(_BaseTestCase):
             try:
                 self.raj._random_key()
             except RandomKeyError as wtf:
-                assert str(wtf) == "redis=Redis<ConnectionPool<Connection<host=localhost,port=6379,db=0>>>"
+                assert str(wtf) == f"redis=Redis<ConnectionPool<Connection<host=localhost,port=6379,db={self.redis_db}>>>"
             else:  # pragma: no cover
                 self.fail(msg='RandomKeyError not raised')
 

--- a/tests/test_bloom.py
+++ b/tests/test_bloom.py
@@ -15,7 +15,7 @@ from tests.base import TestCase  # type: ignore
 
 
 class BloomFilterTests(TestCase):
-    _KEY = f'{TestCase._TEST_KEY_PREFIX}dilberts'
+    _KEY = 'dilberts'
 
     def test_init_without_iterable(self):
         'Test BloomFilter.__init__() without an iterable for initialization'
@@ -203,7 +203,7 @@ class BloomFilterTests(TestCase):
 class RecentlyConsumedTests(TestCase):
     "Simulate reddit's recently consumed problem to test our Bloom filter."
 
-    _KEY = f'{TestCase._TEST_KEY_PREFIX}recently-consumed'
+    _KEY = 'recently-consumed'
 
     def setUp(self):
         super().setUp()

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -20,8 +20,8 @@ from tests.base import TestCase  # type: ignore
 
 
 class CacheDecoratorTests(TestCase):
-    _KEY_EXPIRATION = f'{TestCase._TEST_KEY_PREFIX}expensive-method-expiration'
-    _KEY_NO_EXPIRATION = f'{TestCase._TEST_KEY_PREFIX}expensive-method-no-expiration'
+    _KEY_EXPIRATION = 'expensive-method-expiration'
+    _KEY_NO_EXPIRATION = 'expensive-method-no-expiration'
 
     def setUp(self):
         super().setUp()
@@ -283,8 +283,8 @@ class CacheDecoratorTests(TestCase):
 
 
 class CachedOrderedDictTests(TestCase):
-    _KEY_EXPIRATION = f'{TestCase._TEST_KEY_PREFIX}cached-ordereddict-expiration'
-    _KEY_NO_EXPIRATION = f'{TestCase._TEST_KEY_PREFIX}cached-ordereddict-no-expiration'
+    _KEY_EXPIRATION = 'cached-ordereddict-expiration'
+    _KEY_NO_EXPIRATION = 'cached-ordereddict-no-expiration'
 
     def setUp(self):
         super().setUp()

--- a/tests/test_dict.py
+++ b/tests/test_dict.py
@@ -56,7 +56,7 @@ class DictTests(TestCase):
             )
         except KeyExistsError as wtf:
             assert repr(wtf) == (
-                "KeyExistsError(redis=Redis<ConnectionPool<Connection<host=localhost,port=6379,db=0>>>, "
+                f"KeyExistsError(redis=Redis<ConnectionPool<Connection<host=localhost,port=6379,db={self.redis_db}>>>, "
                 "key='pottery:tel')"
             )
         else:  # pragma: no cover
@@ -81,7 +81,7 @@ class DictTests(TestCase):
             )
         except KeyExistsError as wtf:
             assert str(wtf) == (
-                "redis=Redis<ConnectionPool<Connection<host=localhost,port=6379,db=0>>> "
+                f"redis=Redis<ConnectionPool<Connection<host=localhost,port=6379,db={self.redis_db}>>> "
                 "key='pottery:tel'"
             )
         else:  # pragma: no cover

--- a/tests/test_hyper.py
+++ b/tests/test_hyper.py
@@ -11,7 +11,7 @@ from tests.base import TestCase  # type: ignore
 
 
 class HyperLogLogTests(TestCase):
-    _KEY = f'{TestCase._TEST_KEY_PREFIX}hll'
+    _KEY = 'hll'
 
     def test_init_without_iterable(self):
         hll = HyperLogLog(redis=self.redis)

--- a/tests/test_hyper.py
+++ b/tests/test_hyper.py
@@ -64,9 +64,9 @@ class HyperLogLogTests(TestCase):
     def test_union(self):
         hll1 = HyperLogLog({'foo', 'bar', 'zap', 'a'}, redis=self.redis)
         hll2 = HyperLogLog({'a', 'b', 'c', 'foo'}, redis=self.redis)
-        assert len(hll1.union(hll2)) == 6
-        assert len(hll1.union({'b', 'c', 'd', 'foo'})) == 7
-        assert len(hll1.union(hll2, {'b', 'c', 'd', 'baz'})) == 8
+        assert len(hll1.union(hll2, redis=self.redis)) == 6
+        assert len(hll1.union({'b', 'c', 'd', 'foo'}, redis=self.redis)) == 7
+        assert len(hll1.union(hll2, {'b', 'c', 'd', 'baz'}, redis=self.redis)) == 8
 
     def test_repr(self):
         'Test HyperLogLog.__repr__()'

--- a/tests/test_list.py
+++ b/tests/test_list.py
@@ -19,7 +19,7 @@ class ListTests(TestCase):
         https://docs.python.org/3/tutorial/datastructures.html#more-on-lists
     '''
 
-    _KEY = f'{TestCase._TEST_KEY_PREFIX}squares'
+    _KEY = 'squares'
 
     def test_indexerror(self):
         list_ = RedisList(redis=self.redis)
@@ -147,8 +147,8 @@ class ListTests(TestCase):
         assert not squares1 != squares2
 
     def test_eq_same_redis_instance_different_keys(self):
-        key1 = f'{TestCase._TEST_KEY_PREFIX}squares1'
-        key2 = f'{TestCase._TEST_KEY_PREFIX}squares2'
+        key1 = 'squares1'
+        key2 = 'squares2'
         squares1 = RedisList((1, 4, 9, 16, 25), redis=self.redis, key=key1)
         squares2 = RedisList((1, 4, 9, 16, 25), redis=self.redis, key=key2)
         assert squares1 == squares2

--- a/tests/test_redlock.py
+++ b/tests/test_redlock.py
@@ -111,7 +111,7 @@ class RedlockTests(TestCase):
             self.redlock.release()
         except ReleaseUnlockedLock as wtf:
             assert repr(wtf) == (
-                "ReleaseUnlockedLock(masters=[Redis<ConnectionPool<Connection<host=localhost,port=6379,db=0>>>], "
+                f"ReleaseUnlockedLock(masters=[Redis<ConnectionPool<Connection<host=localhost,port=6379,db={self.redis_db}>>>], "
                 "key='redlock:printer')"
             )
 
@@ -120,7 +120,7 @@ class RedlockTests(TestCase):
             self.redlock.release()
         except ReleaseUnlockedLock as wtf:
             assert str(wtf) == (
-                "masters=[Redis<ConnectionPool<Connection<host=localhost,port=6379,db=0>>>], "
+                f"masters=[Redis<ConnectionPool<Connection<host=localhost,port=6379,db={self.redis_db}>>>], "
                 "key='redlock:printer'"
             )
 


### PR DESCRIPTION
In its default configuration, Redis supports 16 databases.  So for unit
tests, chose a random database in the range [1, 15] (inclusive).  This
is because on my local development environment, I use database 0 for
permanent storage for other projects.

Choosing a random database allows us to `FLUSHDB` before and after every
unit test to ensure a clean database.