### PR TITLE
Implement and test redlock() decorator

### DIFF
--- a/pottery/__init__.py
+++ b/pottery/__init__.py
@@ -40,6 +40,7 @@ from .cache import redis_cache  # isort:skip
 from .hyper import HyperLogLog  # isort:skip
 from .nextid import NextId  # isort:skip
 from .redlock import Redlock  # isort:skip
+from .redlock import redlock  # isort:skip
 from .timer import ContextTimer  # isort:skip
 
 from .counter import RedisCounter
@@ -65,6 +66,7 @@ __all__ = [
     'HyperLogLog',
     'NextId',
     'Redlock',
+    'redlock',
     'ContextTimer',
 
     'RedisCounter',

--- a/pottery/annotations.py
+++ b/pottery/annotations.py
@@ -1,0 +1,23 @@
+# --------------------------------------------------------------------------- #
+#   annotations.py                                                            #
+#                                                                             #
+#   Copyright © 2015-2020, Rajiv Bakulesh Shah, original author.              #
+#   All rights reserved.                                                      #
+# --------------------------------------------------------------------------- #
+
+
+from typing import Any
+from typing import Callable
+from typing import Dict
+from typing import List
+from typing import TypeVar
+from typing import Union
+
+
+# A function that receives *args and **kwargs, and returns anything.  Useful
+# for annotating decorators.
+F = TypeVar('F', bound=Callable[..., Any])
+
+
+JSONTypes = Union[None, bool, int, float, str, List[Any], Dict[str, Any]]
+RedisValues = Union[bytes, str, float, int]

--- a/pottery/base.py
+++ b/pottery/base.py
@@ -20,7 +20,6 @@ from types import TracebackType
 from typing import Any
 from typing import ClassVar
 from typing import ContextManager
-from typing import Dict
 from typing import FrozenSet
 from typing import Generator
 from typing import Iterable
@@ -38,6 +37,8 @@ from redis.client import Pipeline
 from typing_extensions import Final
 
 from . import monkey
+from .annotations import JSONTypes
+from .annotations import RedisValues
 from .exceptions import RandomKeyError
 
 
@@ -122,10 +123,6 @@ class _Common:
     #   https://youtu.be/miGolgp9xq8?t=2086
     #   https://stackoverflow.com/a/38534939
     __random_key = _random_key
-
-
-JSONTypes = Union[None, bool, int, float, str, List[Any], Dict[str, Any]]
-RedisValues = Union[bytes, str, float, int]
 
 
 class _Encodable:


### PR DESCRIPTION
This decorator forces the flow of control through a Redlock, allowing
only one thread to execute the decorated function at a time.

I&rsquo;d previously implemented this `redlock()` decorator in my
application here: https://github.com/brainix/spool/blob/8f659f0f94eaebe939fa4b5ae544706a556b8965/spool/stooges.py#L39-L59

But I think that it&rsquo;s generic and battle tested enough at this
point to warrant inclusion in this library.