### PR TITLE
Skip slow doctests; update status badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,6 @@ commands](http://redis.io/commands) are not always fun.  Pottery is a Pythonic
 way to access Redis.  If you know how to use Python dicts, then you already
 know how to use Pottery.
 
-![CodeQL](https://github.com/brainix/pottery/workflows/CodeQL/badge.svg)
 ![Libraries.io dependency status for GitHub repo](https://img.shields.io/librariesio/github/brainix/pottery)
 [![PyPI version](https://badge.fury.io/py/pottery.svg)](https://badge.fury.io/py/pottery)
 

--- a/README.md
+++ b/README.md
@@ -5,14 +5,15 @@ commands](http://redis.io/commands) are not always fun.  Pottery is a Pythonic
 way to access Redis.  If you know how to use Python dicts, then you already
 know how to use Pottery.
 
-![Libraries.io dependency status for GitHub repo](https://img.shields.io/librariesio/github/brainix/pottery)
-[![PyPI version](https://badge.fury.io/py/pottery.svg)](https://badge.fury.io/py/pottery)
+[![Build status](https://github.com/brainix/pottery/workflows/Python%20package/badge.svg?branch=master)](https://github.com/brainix/pottery/actions?query=branch%3Amaster)
+![Dependencies up to date](https://img.shields.io/librariesio/github/brainix/pottery)
+[![Latest released version](https://badge.fury.io/py/pottery.svg)](https://badge.fury.io/py/pottery)
 
-![PyPI - Python Version](https://img.shields.io/pypi/pyversions/pottery)
+![Supported Python versions](https://img.shields.io/pypi/pyversions/pottery)
 
-[![Downloads](https://pepy.tech/badge/pottery)](https://pepy.tech/project/pottery)
-[![Downloads](https://pepy.tech/badge/pottery/month)](https://pepy.tech/project/pottery)
-[![Downloads](https://pepy.tech/badge/pottery/week)](https://pepy.tech/project/pottery)
+[![Total number of downloads](https://pepy.tech/badge/pottery)](https://pepy.tech/project/pottery)
+[![Downloads per month](https://pepy.tech/badge/pottery/month)](https://pepy.tech/project/pottery)
+[![Downloads per week](https://pepy.tech/badge/pottery/week)](https://pepy.tech/project/pottery)
 
 ## Installation
 

--- a/tests/test_doctests.py
+++ b/tests/test_doctests.py
@@ -25,7 +25,7 @@ class DoctestTests(TestCase):  # pragma: no cover
             module = importlib.import_module(f'pottery.{module_name}')
             yield module
 
-    @unittest.skipUnless('CI' in os.environ, 'run (slow) doctests on only CI')
+    @unittest.skip('our doctests run too slowly')
     def test_doctests(self):
         for module in self._modules():
             with self.subTest(module=module):


### PR DESCRIPTION
Skip slow doctests in order to avoid burning too much GitHub Actions time.