### PR TITLE
Delete .tearDown() methods from unit test classes

### DIFF
--- a/tests/base.py
+++ b/tests/base.py
@@ -28,10 +28,7 @@ class TestCase(unittest.TestCase):
         url = f'redis://localhost:6379/{self.redis_db}'
         self.redis = Redis.from_url(url, socket_timeout=1)
         self.redis.flushdb()
-
-    def tearDown(self) -> None:
-        self.redis.flushdb()
-        super().tearDown()
+        self.addCleanup(self.redis.flushdb)
 
 
 def run_doctests() -> NoReturn:  # pragma: no cover

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -53,10 +53,6 @@ class _BaseTestCase(TestCase):
             vegetarian=False,
         )
 
-    def tearDown(self):
-        self.redis.delete('luvh')
-        super().tearDown()
-
 
 class CommonTests(_BaseTestCase):
     def test_out_of_scope(self):

--- a/tests/test_bloom.py
+++ b/tests/test_bloom.py
@@ -231,9 +231,6 @@ class RecentlyConsumedTests(TestCase):
             false_positives=0.001,
         )
 
-    def tearDown(self):
-        super().tearDown()
-
     @staticmethod
     def random_fullname(*, prefix='t3_', size=6):
         alphabet, id36 = string.digits + string.ascii_lowercase, ''

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -44,11 +44,6 @@ class CacheDecoratorTests(TestCase):
         self.expensive_method_expiration.cache_clear()
         self.expensive_method_no_expiration.cache_clear()
 
-    def tearDown(self):
-        self.expensive_method_expiration.cache_clear()
-        self.expensive_method_no_expiration.cache_clear()
-        super().tearDown()
-
     def test_cache(self):
         assert self.expensive_method_expiration.cache_info() == CacheInfo(
             hits=0,

--- a/tests/test_nextid.py
+++ b/tests/test_nextid.py
@@ -26,10 +26,6 @@ class NextIdTests(TestCase):
         for master in self.ids.masters:
             master.set(self.ids.key, 0)
 
-    def tearDown(self):
-        self.redis.delete('nextid:current')
-        super().tearDown()
-
     def test_nextid(self):
         for id_ in range(1, 10):
             with self.subTest(id_=id_):

--- a/tests/test_redlock.py
+++ b/tests/test_redlock.py
@@ -8,7 +8,6 @@
 
 
 import concurrent.futures
-import contextlib
 import time
 
 from pottery import ContextTimer
@@ -30,11 +29,6 @@ class RedlockTests(TestCase):
             key='printer',
             auto_release_time=100,
         )
-
-    def tearDown(self):
-        with contextlib.suppress(AttributeError, ReleaseUnlockedLock):
-            self.redlock.release()
-        super().tearDown()
 
     def test_acquire_and_time_out(self):
         assert not self.redis.exists(self.redlock.key)


### PR DESCRIPTION
I was previously using `.tearDown()` to clean up the Redis database.

Now, we choose a random Redis database number, and we issue `.flushdb()`
before and after every unit test, so we no longer need to do the
`.tearDown()` dance.