### PR TITLE
Use a tuple (instead of a list) for __all__

### DIFF
--- a/pottery/__init__.py
+++ b/pottery/__init__.py
@@ -12,6 +12,11 @@ know how to use Pottery.
 '''
 
 
+from typing import Tuple
+
+from typing_extensions import Final
+
+
 __title__ = 'pottery'
 __version__ = '1.1.0'
 __description__, __long_description__ = (
@@ -50,7 +55,7 @@ from .list import RedisList
 from .set import RedisSet
 
 
-__all__ = [
+__all__: Final[Tuple[str, ...]] = (
     'PotteryError',
     'KeyExistsError',
     'RandomKeyError',
@@ -74,4 +79,4 @@ __all__ = [
     'RedisDict',
     'RedisList',
     'RedisSet',
-]
+)


### PR DESCRIPTION
In modern Python, it looks like tuples are ok for `__all__`.

https://github.com/python/cpython/blob/63298930fb531ba2bb4f23bc3b915dbf1e17e9e1/Lib/concurrent/futures/__init__.py#L20-L33