### PR TITLE
Make _default.default bound method; fix #323

### DIFF
--- a/pottery/monkey.py
+++ b/pottery/monkey.py
@@ -1,7 +1,7 @@
 # --------------------------------------------------------------------------- #
 #   monkey.py                                                                 #
 #                                                                             #
-#   Copyright © 2015-2021, Rajiv Bakulesh Shah, original author.              #
+#   Copyright © 2015-2021, original authors.                                  #
 #   All rights reserved.                                                      #
 # --------------------------------------------------------------------------- #
 'Monkey patches.'
@@ -55,7 +55,7 @@ def _default(self: Any, obj: Any) -> Union[Dict[str, Any], List[Any], str]:
     return return_value
 
 import json  # isort:skip
-_default.default = json.JSONEncoder.default  # type: ignore
+_default.default = json.JSONEncoder().default  # type: ignore
 json.JSONEncoder.default = _default  # type: ignore
 
 _logger.info(

--- a/tests/test_monkey.py
+++ b/tests/test_monkey.py
@@ -1,0 +1,22 @@
+# --------------------------------------------------------------------------- #
+#   test_monkey.py                                                            #
+#                                                                             #
+#   Copyright © 2015-2021, original authors.                                  #
+#   All rights reserved.                                                      #
+# --------------------------------------------------------------------------- #
+
+
+import json
+
+from tests.base import TestCase
+
+
+class MonkeyPatchTests(TestCase):
+    def test_json_encoder(self):
+        try:
+            json.dumps(object())
+        except TypeError as error:
+            assert str(error) in {
+                "Object of type 'object' is not JSON serializable",  # Python 3.6
+                'Object of type object is not JSON serializable',    # Python 3.7+
+            }


### PR DESCRIPTION
Previously, our JSON encoder monkey patch was to an unbound method.
This resulted in throwing a misleading `TypeError` when trying to encode
something non-encodable.