### PR TITLE
Fix bugs in RedisDeque.rotate()

### DIFF
--- a/pottery/__init__.py
+++ b/pottery/__init__.py
@@ -18,7 +18,7 @@ from typing_extensions import Final
 
 
 __title__ = 'pottery'
-__version__ = '1.1.1'
+__version__ = '1.1.2'
 __description__, __long_description__ = (
     s.strip() for s in __doc__.split(sep='\n\n', maxsplit=1)
 )

--- a/pottery/base.py
+++ b/pottery/base.py
@@ -53,6 +53,7 @@ def random_key(*,
                length: int = 16,
                num_tries: int = 3,
                ) -> str:
+    'Find/return a random key that does not exist in the Redis instance.'
     if not isinstance(num_tries, int):
         raise TypeError('num_tries must be an int >= 0')
     elif num_tries < 0:
@@ -75,6 +76,8 @@ def random_key(*,
 
 
 class _Common:
+    'Mixin class that implements self.redis and self.key properties.'
+
     _RANDOM_KEY_PREFIX: ClassVar[str] = 'pottery:'
 
     def __init__(self,
@@ -126,6 +129,8 @@ class _Common:
 
 
 class _Encodable:
+    'Mixin class that implements JSON encoding and decoding.'
+
     @staticmethod
     def _encode(value: JSONTypes) -> str:
         encoded = json.dumps(value, sort_keys=True)
@@ -138,6 +143,8 @@ class _Encodable:
 
 
 class _Comparable(metaclass=abc.ABCMeta):
+    'Mixin class that implements equality testing for Redis-backed collections.'
+
     @property
     @abc.abstractmethod
     def redis(self) -> Redis:
@@ -165,6 +172,8 @@ class _Comparable(metaclass=abc.ABCMeta):
 
 
 class _Clearable(metaclass=abc.ABCMeta):
+    'Mixin class that implements clearing (emptying) a Redis-backed collection.'
+
     @property
     @abc.abstractmethod
     def redis(self) -> Redis:
@@ -181,6 +190,12 @@ class _Clearable(metaclass=abc.ABCMeta):
 
 
 class _ContextPipeline:
+    '''Context manager that sets up, then executes, a Redis pipeline.
+
+    Redis pipelines: https://redis.io/topics/pipelining
+    Redis transactions: https://redis.io/topics/transactions
+    '''
+
     def __init__(self, redis: Redis) -> None:
         self.redis = redis
 
@@ -245,10 +260,12 @@ class _Pipelined(metaclass=abc.ABCMeta):
 
 
 class Base(_Common, _Encodable, _Comparable, _Clearable, _Pipelined):
-    ...
+    'Base class for Redis-backed collections.'
 
 
 class Iterable_(metaclass=abc.ABCMeta):
+    'Mixin class that implements iterating over a Redis-backed collection.'
+
     @staticmethod  # pragma: no cover
     @abc.abstractmethod
     def _decode(value: bytes) -> JSONTypes:
@@ -276,6 +293,8 @@ class Iterable_(metaclass=abc.ABCMeta):
 
 
 class Primitive(metaclass=abc.ABCMeta):
+    'Base class for Redis-backed distributed primitives.'
+
     _DEFAULT_MASTERS: ClassVar[FrozenSet[Redis]] = frozenset({_default_redis})
 
     def __init__(self,

--- a/pottery/bloom.py
+++ b/pottery/bloom.py
@@ -25,6 +25,7 @@ from .base import JSONTypes
 
 
 def _store_on_self(*, attr: str) -> Callable[[F], F]:
+    "Decorator to store/cache a method's return value as an attribute on self."
     def decorator(func: F) -> F:
         @functools.wraps(func)
         def wrapper(self: Any, *args: Any, **kwargs: Any) -> Any:
@@ -39,6 +40,15 @@ def _store_on_self(*, attr: str) -> Callable[[F], F]:
 
 
 class BloomFilterABC(metaclass=abc.ABCMeta):
+    '''Bloom filter abstract base class.
+
+    This abstract base class:
+        1. Defines the abstract methods that the concrete implementation class
+           must define (having to do with encoding/decoding, I/O, and storage)
+        2. Implements numerical recipes on the number of elements that you want
+           to insert, and the acceptable false positive rate
+    '''
+
     @abc.abstractmethod
     def _bit_offsets(self,
                      encoded_value: JSONTypes,

--- a/pottery/cache.py
+++ b/pottery/cache.py
@@ -42,6 +42,11 @@ _logger: Final[logging.Logger] = logging.getLogger('pottery')
 
 
 class CacheInfo(NamedTuple):
+    '''Caching decorator information.
+
+    This CacheInfo named tuple is compatible with the one in functools:
+        https://github.com/python/cpython/blob/7a34380ad788886f5ad50d4175ceb2d5715b8cff/Lib/functools.py#L430
+    '''
     hits: int = 0
     misses: int = 0
     maxsize: Optional[int] = None

--- a/pottery/deque.py
+++ b/pottery/deque.py
@@ -126,9 +126,9 @@ class RedisDeque(RedisList, collections.deque):  # type: ignore
         if n:
             with self._watch() as pipeline:
                 push_method = 'lpush' if n > 0 else 'rpush'
-                values = self[-n:] if n > 0 else self[:-n]
+                values = reversed(self[-n:]) if n > 0 else self[:-n]
                 encoded_values = (self._encode(element) for element in values)
-                trim_indices = (0, len(self)-n) if n > 0 else (-n, len(self))
+                trim_indices = (0, len(self)-1) if n > 0 else (-n, len(self)-n-1)
 
                 pipeline.multi()
                 getattr(pipeline, push_method)(self.key, *encoded_values)

--- a/tests/test_deque.py
+++ b/tests/test_deque.py
@@ -100,6 +100,35 @@ class DequeTests(TestCase):
         d.rotate(0)
         assert d == ['g', 'h', 'i', 'j', 'k', 'l']
 
+    def test_rotate_right(self):
+        'A positive number rotates a RedisDeque right'
+        # I got this example from here:
+        #   https://pymotw.com/2/collections/deque.html#rotating
+        d = RedisDeque(range(10))
+        d.rotate(2)
+        assert d == [8, 9, 0, 1, 2, 3, 4, 5, 6, 7]
+
+    def test_rotate_left(self):
+        'A negative number rotates a RedisDeque left'
+        # I got this example from here:
+        #   https://pymotw.com/2/collections/deque.html#rotating
+        d = RedisDeque(range(10))
+        d.rotate(-2)
+        assert d == [2, 3, 4, 5, 6, 7, 8, 9, 0, 1]
+
+    def test_delete_nth(self):
+        'Recipe for deleting the nth element from a RedisDeque'
+        d = RedisDeque(('g', 'h', 'i', 'j', 'k', 'l'), redis=self.redis)
+
+        # Delete the 3rd element in the deque, or the 'j'.  I got this recipe
+        # from here:
+        #   https://docs.python.org/3.9/library/collections.html#deque-recipes
+        d.rotate(-3)
+        e = d.popleft()
+        d.rotate(3)
+        assert e == 'j'
+        assert d == ['g', 'h', 'i', 'k', 'l']
+
     def test_repr(self):
         d = RedisDeque(redis=self.redis)
         assert repr(d) == 'RedisDeque([])'


### PR DESCRIPTION
Previously, `values` and `trim_indices` were wrong, resulting in
incorrectly rotated deques.

I've fixed the bug and written unit tests to prevent a regression.