### PR TITLE
Fix bug in RedisList slicing

### DIFF
--- a/pottery/__init__.py
+++ b/pottery/__init__.py
@@ -18,7 +18,7 @@ from typing_extensions import Final
 
 
 __title__ = 'pottery'
-__version__ = '1.1.2'
+__version__ = '1.1.3'
 __description__, __long_description__ = (
     s.strip() for s in __doc__.split(sep='\n\n', maxsplit=1)
 )

--- a/pottery/counter.py
+++ b/pottery/counter.py
@@ -103,7 +103,7 @@ class RedisCounter(RedisDict, collections.Counter):
                 for key, value in encoded_dict.items()
             }
             counter.update(decoded_dict)
-            if cursor == 0:  # pragma: no cover
+            if cursor == 0:
                 break
         return counter
 

--- a/pottery/deque.py
+++ b/pottery/deque.py
@@ -46,7 +46,7 @@ class RedisDeque(RedisList, collections.deque):  # type: ignore
         if self.maxlen is not None:
             if self.maxlen:
                 iterable = tuple(iterable)[-self.maxlen:]
-            else:  # pragma: no cover
+            else:
                 iterable = tuple()
         super()._populate(pipeline, iterable)
 

--- a/pottery/hyper.py
+++ b/pottery/hyper.py
@@ -64,7 +64,7 @@ class HyperLogLog(Base):
                 if isinstance(obj, self.__class__):
                     if self.redis.connection_pool == obj.redis.connection_pool:
                         other_hll_keys.append(obj.key)
-                    else:  # pragma: no cover
+                    else:
                         raise RuntimeError(
                             f"can't update {self} with {obj} as they live on "
                             "different Redis instances/databases"

--- a/pottery/list.py
+++ b/pottery/list.py
@@ -43,7 +43,13 @@ class RedisList(Base, collections.abc.MutableSequence):
     def __slice_to_indices(self, slice_or_index: Union[slice, int]) -> range:
         try:
             start = cast(slice, slice_or_index).start or 0
-            stop = cast(slice, slice_or_index).stop or len(self)
+            if (
+                cast(slice, slice_or_index).start is None
+                and cast(slice, slice_or_index).stop == 0
+            ):
+                stop = 0
+            else:
+                stop = cast(slice, slice_or_index).stop or len(self)
             step = cast(slice, slice_or_index).step or 1
         except AttributeError:
             start = slice_or_index
@@ -72,7 +78,7 @@ class RedisList(Base, collections.abc.MutableSequence):
                   iterable: Iterable[JSONTypes] = tuple(),
                   ) -> None:
         encoded_values = [self._encode(value) for value in iterable]
-        if encoded_values:  # pragma: no cover
+        if encoded_values:
             pipeline.multi()
             pipeline.rpush(self.key, *encoded_values)
 
@@ -143,7 +149,7 @@ class RedisList(Base, collections.abc.MutableSequence):
         for index in indices:
             pipeline.lset(self.key, index, 0)
             num += 1
-        if num:  # pragma: no cover
+        if num:
             pipeline.lrem(self.key, num, 0)
 
     def __len__(self) -> int:

--- a/tests/test_counter.py
+++ b/tests/test_counter.py
@@ -99,6 +99,12 @@ class CounterTests(TestCase):
             "RedisCounter{'ham': 1, 'eggs': 1}",
         }
 
+    def test_make_counter(self):
+        'Test RedisCounter._make_counter()'
+        kwargs = {str(element): element for element in range(1000)}
+        c = RedisCounter(redis=self.redis, **kwargs)._make_counter()
+        assert c == collections.Counter(**kwargs)
+
     def test_add(self):
         'Test RedisCounter.__add__()'
         c = RedisCounter(redis=self.redis, a=3, b=1)

--- a/tests/test_deque.py
+++ b/tests/test_deque.py
@@ -56,6 +56,13 @@ class DequeTests(TestCase):
             delete.return_value = None
             RedisDeque(redis=self.redis, maxlen='2')
 
+    def test_init_with_maxlen(self):
+        d = RedisDeque([1, 2, 3, 4, 5, 6], redis=self.redis, maxlen=3)
+        assert d == [4, 5, 6]
+
+        d = RedisDeque([1, 2, 3, 4, 5, 6], redis=self.redis, maxlen=0)
+        assert d == []
+
     def test_persistent_deque_bigger_than_maxlen(self):
         d1 = RedisDeque('ghi', redis=self.redis)
         d1  # Workaround for Pyflakes.  :-(

--- a/tests/test_hyper.py
+++ b/tests/test_hyper.py
@@ -6,6 +6,8 @@
 # --------------------------------------------------------------------------- #
 
 
+from redis import Redis
+
 from pottery import HyperLogLog
 from tests.base import TestCase  # type: ignore
 
@@ -60,6 +62,12 @@ class HyperLogLogTests(TestCase):
         hll1 = HyperLogLog({'foo', 'bar', 'zap', 'a'}, redis=self.redis)
         hll1.update(hll2, {'b', 'c', 'd', 'baz'})
         assert len(hll1) == 8
+
+    def test_update_different_redis_instances(self):
+        hll1 = HyperLogLog({'foo', 'bar', 'zap', 'a'}, redis=self.redis)
+        hll2 = HyperLogLog({'a', 'b', 'c', 'foo'}, redis=Redis())
+        with self.assertRaises(RuntimeError):
+            hll1.update(hll2)
 
     def test_union(self):
         hll1 = HyperLogLog({'foo', 'bar', 'zap', 'a'}, redis=self.redis)

--- a/tests/test_list.py
+++ b/tests/test_list.py
@@ -32,6 +32,10 @@ class ListTests(TestCase):
         with self.assertRaises(KeyExistsError):
             RedisList((1, 4, 9, 16, 25), redis=self.redis, key=self._KEY)
 
+    def test_init_empty_list(self):
+        squares = RedisList(redis=self.redis, key=self._KEY)
+        assert squares == []
+
     def test_basic_usage(self):
         squares = RedisList((1, 4, 9, 16, 25), redis=self.redis)
         assert squares == [1, 4, 9, 16, 25]
@@ -113,6 +117,8 @@ class ListTests(TestCase):
         del a[0]
         assert a == [1, 66.25, 333, 333, 1234.5]
         del a[2:4]
+        assert a == [1, 66.25, 1234.5]
+        del a[:0]
         assert a == [1, 66.25, 1234.5]
         del a[:]
         assert a == []


### PR DESCRIPTION
This was the previous buggy behavior:

```python
>>> a = RedisList((1, 66.25, 1234.5))
>>> del a[:0]
>>> a
[]
```

This is the current correct behavior:

```python
>>> a = RedisList((1, 66.25, 1234.5))
>>> del a[:0]
>>> a
[1, 66.25, 1234.5]
```