### PR TITLE
Simplify RedisList.__slice_to_indices()

### DIFF
--- a/pottery/deque.py
+++ b/pottery/deque.py
@@ -128,7 +128,7 @@ class RedisDeque(RedisList, collections.deque):  # type: ignore
         if n:
             with self._watch() as pipeline:
                 push_method = 'lpush' if n > 0 else 'rpush'
-                values = reversed(self[-n:]) if n > 0 else self[:-n]
+                values = self[-n:][::-1] if n > 0 else self[:-n]
                 encoded_values = (self._encode(element) for element in values)
                 trim_indices = (0, len(self)-1) if n > 0 else (-n, len(self)-n-1)
 

--- a/pottery/list.py
+++ b/pottery/list.py
@@ -42,17 +42,9 @@ class RedisList(Base, collections.abc.MutableSequence):
 
     def __slice_to_indices(self, slice_or_index: Union[slice, int]) -> range:
         try:
-            start = cast(slice, slice_or_index).start or 0
-            if (
-                cast(slice, slice_or_index).start is None
-                and cast(slice, slice_or_index).stop == 0
-            ):
-                stop = 0
-            else:
-                stop = cast(slice, slice_or_index).stop or len(self)
-            step = cast(slice, slice_or_index).step or 1
+            start, stop, step = cast(slice, slice_or_index).indices(len(self))
         except AttributeError:
-            start = slice_or_index
+            start = cast(int, slice_or_index)
             stop = cast(int, slice_or_index) + 1
             step = 1
         indices = range(start, stop, step)


### PR DESCRIPTION
Apparently, Python has a built-in `slice.indices()` method.  Reuse it
for our nefarious purposes.