### PR TITLE
Write clearer pipeline blocks

### DIFF
--- a/pottery/list.py
+++ b/pottery/list.py
@@ -172,7 +172,7 @@ class RedisList(Base, collections.abc.MutableSequence):
             # supports inserting an element before a given (pivot) *value.*  So
             # our ridiculous hack is to set the pivot value to 0, then to
             # insert the desired value before the value 0, then to set the
-            # value 0 to the original pivot value.
+            # value 0 back to the original pivot value.
             #
             # More info:
             #   http://redis.io/commands/linsert
@@ -194,10 +194,9 @@ class RedisList(Base, collections.abc.MutableSequence):
 
     def sort(self, *, key: Optional[str] = None, reverse: bool = False) -> None:
         'Sort a RedisList in place.  O(n)'
-        if key is None:
-            self.redis.sort(self.key, desc=reverse, store=self.key)
-        else:
+        if key is not None:
             raise NotImplementedError('sorting by key not implemented')
+        self.redis.sort(self.key, desc=reverse, store=self.key)
 
     def __eq__(self, other: Any) -> bool:
         if super().__eq__(other):


### PR DESCRIPTION
It's ok to use the Redis client directly to get data without making
changes within pipeline blocks, rather than forcing ourselves to use the
pipeline exclusively, since the pipeline does optimistic locking
regardless.