### PR TITLE
Remove heroku update from Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,6 @@ upgrade:
 	-brew update
 	-brew upgrade $(formulae)
 	brew cleanup
-	-heroku update
 ifneq ($(recursive),)
 	rm -rf $(venv)
 	~/.pyenv/versions/$(version)/bin/python3 -m venv $(venv)

--- a/pottery/deque.py
+++ b/pottery/deque.py
@@ -129,7 +129,7 @@ class RedisDeque(RedisList, collections.deque):  # type: ignore
                 f"'{n.__class__.__name__}' object cannot be interpreted "
                 'as an integer'
             )
-        if not n:
+        if n == 0:
             return
 
         with self._watch() as pipeline:


### PR DESCRIPTION
We don't use Heroku for anything in this project.  I must've
copy/pasta'ed `heroku update` into the Makefile from a different
project.