### PR TITLE
Fix Redlock.acquire() type annotation

### DIFF
--- a/pottery/redlock.py
+++ b/pottery/redlock.py
@@ -293,7 +293,7 @@ class Redlock(Primitive):
             self.__release()
         return False
 
-    def acquire(self, *, blocking: bool = True, timeout: int = -1) -> bool:
+    def acquire(self, *, blocking: bool = True, timeout: float = -1) -> bool:
         '''Lock the lock.
 
         If blocking is True and timeout is -1, then wait for as long as


### PR DESCRIPTION
Make Pottery's `Redlock.acquire()` type annotation match Python's
`Lock.acquire()`.

Pottery's implementation already works with `int` or `float` timeout
values.  All that's required is to make the type annotation more
generic.

https://github.com/python/typeshed/blob/8eaffee63a4b976008875e5f3d6cc00f3ce69b39/stdlib/threading.pyi#L93