### PR TITLE
Make .__exit__() return a bool

### DIFF
--- a/pottery/base.py
+++ b/pottery/base.py
@@ -46,6 +46,7 @@ from redis import Redis
 from redis import RedisError
 from redis.client import Pipeline
 from typing_extensions import Final
+from typing_extensions import Literal
 
 from . import monkey
 from .annotations import JSONTypes
@@ -218,7 +219,7 @@ class _ContextPipeline:
                  exc_type: None,
                  exc_value: None,
                  exc_traceback: None,
-                 ) -> None:
+                 ) -> Literal[False]:
         raise NotImplementedError
 
     @overload
@@ -226,19 +227,20 @@ class _ContextPipeline:
                  exc_type: Type[BaseException],
                  exc_value: BaseException,
                  exc_traceback: TracebackType,
-                 ) -> None:
+                 ) -> Literal[False]:
         raise NotImplementedError
 
     def __exit__(self,
                  exc_type: Optional[Type[BaseException]],
                  exc_value: Optional[BaseException],
                  exc_traceback: Optional[TracebackType],
-                 ) -> None:
+                 ) -> Literal[False]:
         if exc_type is None:
             with contextlib.suppress(RedisError):
                 self.pipeline.multi()
                 self.pipeline.ping()
             self.pipeline.execute()
+        return False
 
 
 class _Pipelined(metaclass=abc.ABCMeta):

--- a/pottery/timer.py
+++ b/pottery/timer.py
@@ -23,6 +23,8 @@ from typing import Optional
 from typing import Type
 from typing import overload
 
+from typing_extensions import Literal
+
 
 class ContextTimer:
     '''Measure the execution time of small code snippets.
@@ -70,7 +72,7 @@ class ContextTimer:
                  exc_type: None,
                  exc_value: None,
                  exc_traceback: None,
-                 ) -> None:
+                 ) -> Literal[False]:
         raise NotImplementedError
 
     @overload
@@ -78,15 +80,16 @@ class ContextTimer:
                  exc_type: Type[BaseException],
                  exc_value: BaseException,
                  exc_traceback: TracebackType,
-                 ) -> None:
+                 ) -> Literal[False]:
         raise NotImplementedError
 
     def __exit__(self,
                  exc_type: Optional[Type[BaseException]],
                  exc_value: Optional[BaseException],
                  exc_traceback: Optional[TracebackType],
-                 ) -> None:
+                 ) -> Literal[False]:
         self.__stop()
+        return False
 
     def start(self) -> None:
         if self._stopped:


### PR DESCRIPTION
If `.__exit__()` returns `False`, any potential exception arising from
the `with` block is propagated.

If `.__exit__()` returns `True`, the exception is suppressed.

https://docs.python.org/3/library/stdtypes.html#contextmanager.__exit__