### PR TITLE
Don't let RedisLists equal tuples

### DIFF
--- a/pottery/list.py
+++ b/pottery/list.py
@@ -209,7 +209,7 @@ class RedisList(Base, collections.abc.MutableSequence):
                 if len(self) != len(other):
                     # self and other are different lengths.
                     return False
-                elif isinstance(other, collections.abc.Sequence):
+                elif isinstance(other, collections.abc.MutableSequence):
                     # self and other are the same length, and other is an
                     # ordered collection too.  Compare self's and other's
                     # elements, pair by pair.

--- a/pottery/nextid.py
+++ b/pottery/nextid.py
@@ -191,6 +191,7 @@ class NextId(Primitive):
                 else:
                     if num_masters_set > len(self.masters) // 2:  # pragma: no cover
                         return
+
         raise QuorumNotAchieved(self.key, self.masters)
 
 

--- a/tests/test_list.py
+++ b/tests/test_list.py
@@ -172,13 +172,13 @@ class ListTests(TestCase):
 
     def test_eq_different_lengths(self):
         squares1 = RedisList((1, 4, 9, 16, 25), redis=self.redis)
-        squares2 = (1, 4, 9, 16, 25, 36)
+        squares2 = [1, 4, 9, 16, 25, 36]
         assert not squares1 == squares2
         assert squares1 != squares2
 
     def test_eq_different_items(self):
         squares1 = RedisList((1, 4, 9, 16, 25), redis=self.redis)
-        squares2 = (4, 9, 16, 25, 36)
+        squares2 = [4, 9, 16, 25, 36]
         assert not squares1 == squares2
         assert squares1 != squares2
 
@@ -192,6 +192,12 @@ class ListTests(TestCase):
         squares = RedisList((1, 4, 9, 16, 25), redis=self.redis)
         assert not squares == None
         assert squares != None
+
+    def test_eq_tuple(self):
+        squares = RedisList((1, 4, 9, 16, 25), redis=self.redis)
+        assert squares == [1, 4, 9, 16, 25]
+        assert not squares == (1, 4, 9, 16, 25)
+        assert squares != (1, 4, 9, 16, 25)
 
     def test_repr(self):
         squares = RedisList((1, 4, 9, 16, 25), redis=self.redis)


### PR DESCRIPTION
This is how Python behaves:

```python
>>> [1, 2, 3] == (1, 2, 3)
False
```

As of this PR, this is also how Pottery behaves:

```python
>>> from pottery import RedisList
>>> RedisList((1, 2, 3)) == (1, 2, 3)
False
```