### PR TITLE
Improve redis_cache() documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -439,21 +439,21 @@ Two caveats:
 
 ## redis_cache()
 
-`redis_cache()` is a simple function return value cache, sometimes called
+`redis_cache()` is a simple lightweight unbounded function return value cache,
+sometimes called
 [&ldquo;memoize&rdquo;](https://en.wikipedia.org/wiki/Memoization).
 `redis_cache()` implements Python&rsquo;s excellent
-[`functools.lru_cache()`](https://docs.python.org/3/library/functools.html#functools.lru_cache)
+[`functools.cache()`](https://docs.python.org/3/library/functools.html#functools.cache)
 API as closely as is feasible.  In other words, you can use `redis_cache()` the
-same way that you use `functools.lru_cache()`.
+same way that you use `functools.cache()`.
 
 _Limitations:_
 
 1. Arguments to the function must be hashable.
 2. Return values from the function must be JSON serializable.
-3. `functools.lru_cache()` allows for a maximum size and has an eviction
-   policy; `redis_cache()` has neither.  This means that your function&rsquo;s
-   return value cache can grow unbounded.  Only use `redis_cache()` in any of
-   these cases:
+3. Just like `functools.cache()`, `redis_cache()` does not allow for a maximum
+   size, and does not evict old values, and grows unbounded.  Only use
+   `redis_cache()` in one of these cases:
     1. Your function&rsquo;s argument space has a known small cardinality.
     2. You specify a `timeout` when calling `redis_cache()` to decorate your
        function, to dump your _entire_ return value cache `timeout` seconds

--- a/pottery/list.py
+++ b/pottery/list.py
@@ -39,12 +39,12 @@ from .exceptions import KeyExistsError
 
 def _raise_on_error(func: F) -> Callable[[F], F]:
     @functools.wraps(func)
-    def wrap(*args: Any, **kwargs: Any) -> Any:
+    def wrapper(*args: Any, **kwargs: Any) -> Any:
         try:
             return func(*args, **kwargs)
         except ResponseError as error:
             raise IndexError('list assignment index out of range') from error
-    return wrap
+    return wrapper
 
 
 class RedisList(Base, collections.abc.MutableSequence):

--- a/tests/test_doctests.py
+++ b/tests/test_doctests.py
@@ -40,6 +40,7 @@ class DoctestTests(TestCase):  # pragma: no cover
         'our doctests run too slowly',
     )
     def test_doctests(self):
+        'Run doctests and confirm that they work and are not science fiction'
         for module in self._modules():
             with self.subTest(module=module):
                 results = doctest.testmod(m=module)


### PR DESCRIPTION
`redis_cache()` is more similar to `functools.cache()` than
`functools.lru_cache()`.