### PR TITLE
Raise exception if quorum is impossible

### DIFF
--- a/pottery/__init__.py
+++ b/pottery/__init__.py
@@ -46,6 +46,7 @@ from .exceptions import PotteryError  # isort:skip
 from .exceptions import KeyExistsError  # isort:skip
 from .exceptions import RandomKeyError  # isort:skip
 from .exceptions import PrimitiveError  # isort:skip
+from .exceptions import QuorumIsImpossible  # isort:skip
 from .exceptions import QuorumNotAchieved  # isort:skip
 from .exceptions import TooManyExtensions  # isort:skip
 from .exceptions import ExtendUnlockedLock  # isort:skip
@@ -72,6 +73,7 @@ __all__: Final[Tuple[str, ...]] = (
     'KeyExistsError',
     'RandomKeyError',
     'PrimitiveError',
+    'QuorumIsImpossible',
     'QuorumNotAchieved',
     'TooManyExtensions',
     'ExtendUnlockedLock',

--- a/pottery/__init__.py
+++ b/pottery/__init__.py
@@ -30,7 +30,7 @@ from typing_extensions import Final
 
 
 __title__ = 'pottery'
-__version__ = '1.1.8'
+__version__ = '1.2.0'
 __description__, __long_description__ = (
     s.strip() for s in __doc__.split(sep='\n\n', maxsplit=1)
 )

--- a/pottery/base.py
+++ b/pottery/base.py
@@ -350,10 +350,10 @@ class Primitive(metaclass=abc.ABCMeta):
     def key(self, value: str) -> None:
         self._key = f'{self.KEY_PREFIX}:{value}'
 
-    def _raise_on_redis_errors(self,
-                               raise_on_redis_errors: Optional[bool],
-                               redis_errors: List[RedisError],
-                               ) -> None:
+    def _check_enough_masters_up(self,
+                                 raise_on_redis_errors: Optional[bool],
+                                 redis_errors: List[RedisError],
+                                 ) -> None:
         if raise_on_redis_errors is None:
             raise_on_redis_errors = self.raise_on_redis_errors
         if raise_on_redis_errors and len(redis_errors) > len(self.masters) // 2:

--- a/pottery/exceptions.py
+++ b/pottery/exceptions.py
@@ -20,6 +20,7 @@ from typing import Iterable
 from typing import Optional
 
 from redis import Redis
+from redis import RedisError
 
 
 class PotteryError(Exception):
@@ -56,18 +57,29 @@ class RandomKeyError(PotteryError, RuntimeError):
 class PrimitiveError(Exception):
     'Base exception class for distributed primitives.'
 
-    def __init__(self, key: str, masters: Iterable[Redis]) -> None:
+    def __init__(self,
+                 key: str,
+                 masters: Iterable[Redis],
+                 *,
+                 redis_errors: Iterable[RedisError] = tuple(),
+                 ) -> None:
         self._key = key
         self._masters = masters
+        self._redis_errors = redis_errors
 
     def __repr__(self) -> str:
         return (
             f"{self.__class__.__name__}(key='{self._key}', "
-            f"masters={list(self._masters)})"
+            f"masters={list(self._masters)}, "
+            f"redis_errors={list(self._redis_errors)})"
         )
 
     def __str__(self) -> str:
-        return f"key='{self._key}', masters={list(self._masters)}"
+        return (
+            f"key='{self._key}', "
+            f"masters={list(self._masters)}, "
+            f"redis_errors={list(self._redis_errors)}"
+        )
 
 class QuorumNotAchieved(PrimitiveError, RuntimeError):
     ...
@@ -79,4 +91,7 @@ class ExtendUnlockedLock(PrimitiveError, RuntimeError):
     ...
 
 class ReleaseUnlockedLock(PrimitiveError, RuntimeError):
+    ...
+
+class QuorumIsImpossible(PrimitiveError, RuntimeError):
     ...

--- a/pottery/exceptions.py
+++ b/pottery/exceptions.py
@@ -82,16 +82,16 @@ class PrimitiveError(Exception):
         )
 
 class QuorumNotAchieved(PrimitiveError, RuntimeError):
-    ...
+    'Consensus-based algorithm could not achieve quorum.'
 
 class TooManyExtensions(PrimitiveError, RuntimeError):
-    ...
+    'Redlock has been extended too many times.'
 
 class ExtendUnlockedLock(PrimitiveError, RuntimeError):
-    ...
+    'Attempting to extend an unlocked Redlock.'
 
 class ReleaseUnlockedLock(PrimitiveError, RuntimeError):
-    ...
+    'Attempting to release an unlocked Redlock.'
 
 class QuorumIsImpossible(PrimitiveError, RuntimeError):
-    ...
+    'Too many Redis masters threw RedisErrors; quorum can not be achieved.'

--- a/pottery/nextid.py
+++ b/pottery/nextid.py
@@ -93,8 +93,8 @@ class NextId(Primitive):
                  *,
                  key: str = KEY,
                  masters: Iterable[Redis] = frozenset(),
-                 num_tries: int = NUM_TRIES,
                  raise_on_redis_errors: bool = False,
+                 num_tries: int = NUM_TRIES,
                  ) -> None:
         super().__init__(
             key=key,
@@ -103,7 +103,6 @@ class NextId(Primitive):
         )
         self.__register_set_id_script()
         self.num_tries = num_tries
-        self.raise_on_redis_errors = raise_on_redis_errors
         self.__init_masters()
 
     # Preserve the Open-Closed Principle with name mangling.

--- a/pottery/nextid.py
+++ b/pottery/nextid.py
@@ -96,7 +96,11 @@ class NextId(Primitive):
                  num_tries: int = NUM_TRIES,
                  raise_on_redis_errors: bool = False,
                  ) -> None:
-        super().__init__(key=key, masters=masters)
+        super().__init__(
+            key=key,
+            masters=masters,
+            raise_on_redis_errors=raise_on_redis_errors,
+        )
         self.__register_set_id_script()
         self.num_tries = num_tries
         self.raise_on_redis_errors = raise_on_redis_errors
@@ -166,15 +170,7 @@ class NextId(Primitive):
 
         if len(current_ids) > len(self.masters) // 2:
             return max(current_ids)
-        if (
-            self.raise_on_redis_errors
-            and len(redis_errors) > len(self.masters) // 2
-        ):
-            raise QuorumIsImpossible(
-                self.key,
-                self.masters,
-                redis_errors=redis_errors,
-            )
+        self._raise_on_redis_errors(None, redis_errors)
         raise QuorumNotAchieved(
             self.key,
             self.masters,
@@ -209,15 +205,7 @@ class NextId(Primitive):
                     if num_masters_set > len(self.masters) // 2:  # pragma: no cover
                         return
 
-        if (
-            self.raise_on_redis_errors
-            and len(redis_errors) > len(self.masters) // 2
-        ):
-            raise QuorumIsImpossible(
-                self.key,
-                self.masters,
-                redis_errors=redis_errors,
-            )
+        self._raise_on_redis_errors(None, redis_errors)
         raise QuorumNotAchieved(
             self.key,
             self.masters,

--- a/pottery/nextid.py
+++ b/pottery/nextid.py
@@ -29,7 +29,9 @@ import contextlib
 import logging
 from typing import ClassVar
 from typing import Iterable
+from typing import List
 from typing import Optional
+from typing import Type
 from typing import cast
 
 from redis import Redis
@@ -38,6 +40,7 @@ from redis.client import Script
 from typing_extensions import Final
 
 from .base import Primitive
+from .exceptions import QuorumIsImpossible
 from .exceptions import QuorumNotAchieved
 from .executor import BailOutExecutor
 
@@ -91,10 +94,12 @@ class NextId(Primitive):
                  key: str = KEY,
                  masters: Iterable[Redis] = frozenset(),
                  num_tries: int = NUM_TRIES,
+                 raise_on_redis_errors: bool = False,
                  ) -> None:
         super().__init__(key=key, masters=masters)
         self.__register_set_id_script()
         self.num_tries = num_tries
+        self.raise_on_redis_errors = raise_on_redis_errors
         self.__init_masters()
 
     # Preserve the Open-Closed Principle with name mangling.
@@ -127,18 +132,15 @@ class NextId(Primitive):
         return self
 
     def __next__(self) -> int:
+        suppressable_errors: List[Type[BaseException]] = [QuorumNotAchieved]
+        if not self.raise_on_redis_errors:
+            suppressable_errors.append(QuorumIsImpossible)
         for _ in range(self.num_tries):
-            with contextlib.suppress(QuorumNotAchieved):
+            with contextlib.suppress(*suppressable_errors):
                 next_id = self.__current_id + 1
                 self.__current_id = next_id
                 return next_id
         raise QuorumNotAchieved(self.key, self.masters)
-
-    def __repr__(self) -> str:
-        return (
-            f'<{self.__class__.__name__} key={self.key} '
-            f'value={self.__current_id}>'
-        )
 
     @property
     def __current_id(self) -> int:
@@ -148,11 +150,12 @@ class NextId(Primitive):
                 future = executor.submit(master.get, self.key)
                 futures.add(future)
 
-            current_ids = []
+            current_ids, redis_errors = [], []
             for future in concurrent.futures.as_completed(futures):
                 try:
                     current_id = int(future.result())
                 except RedisError as error:
+                    redis_errors.append(error)
                     _logger.exception(
                         '%s.__current_id() getter caught %s',
                         self.__class__.__name__,
@@ -163,7 +166,20 @@ class NextId(Primitive):
 
         if len(current_ids) > len(self.masters) // 2:
             return max(current_ids)
-        raise QuorumNotAchieved(self.key, self.masters)
+        if (
+            self.raise_on_redis_errors
+            and len(redis_errors) > len(self.masters) // 2
+        ):
+            raise QuorumIsImpossible(
+                self.key,
+                self.masters,
+                redis_errors=redis_errors,
+            )
+        raise QuorumNotAchieved(
+            self.key,
+            self.masters,
+            redis_errors=redis_errors,
+        )
 
     @__current_id.setter
     def __current_id(self, value: int) -> None:
@@ -178,11 +194,12 @@ class NextId(Primitive):
                 )
                 futures.add(future)
 
-            num_masters_set = 0
+            num_masters_set, redis_errors = 0, []
             for future in concurrent.futures.as_completed(futures):
                 try:
                     num_masters_set += future.result() == value
                 except RedisError as error:
+                    redis_errors.append(error)
                     _logger.exception(
                         '%s.__current_id() setter caught %s',
                         self.__class__.__name__,
@@ -192,7 +209,26 @@ class NextId(Primitive):
                     if num_masters_set > len(self.masters) // 2:  # pragma: no cover
                         return
 
-        raise QuorumNotAchieved(self.key, self.masters)
+        if (
+            self.raise_on_redis_errors
+            and len(redis_errors) > len(self.masters) // 2
+        ):
+            raise QuorumIsImpossible(
+                self.key,
+                self.masters,
+                redis_errors=redis_errors,
+            )
+        raise QuorumNotAchieved(
+            self.key,
+            self.masters,
+            redis_errors=redis_errors,
+        )
+
+    def __repr__(self) -> str:
+        return (
+            f'<{self.__class__.__name__} key={self.key} '
+            f'value={self.__current_id}>'
+        )
 
 
 if __name__ == '__main__':

--- a/pottery/nextid.py
+++ b/pottery/nextid.py
@@ -169,7 +169,7 @@ class NextId(Primitive):
 
         if len(current_ids) > len(self.masters) // 2:
             return max(current_ids)
-        self._raise_on_redis_errors(None, redis_errors)
+        self._check_enough_masters_up(None, redis_errors)
         raise QuorumNotAchieved(
             self.key,
             self.masters,
@@ -204,7 +204,7 @@ class NextId(Primitive):
                     if num_masters_set > len(self.masters) // 2:  # pragma: no cover
                         return
 
-        self._raise_on_redis_errors(None, redis_errors)
+        self._check_enough_masters_up(None, redis_errors)
         raise QuorumNotAchieved(
             self.key,
             self.masters,

--- a/pottery/redlock.py
+++ b/pottery/redlock.py
@@ -58,6 +58,7 @@ from typing_extensions import Literal
 from .annotations import F
 from .base import Primitive
 from .exceptions import ExtendUnlockedLock
+from .exceptions import QuorumIsImpossible
 from .exceptions import ReleaseUnlockedLock
 from .exceptions import TooManyExtensions
 from .executor import BailOutExecutor
@@ -160,6 +161,7 @@ class Redlock(Primitive):
                  masters: Iterable[Redis] = frozenset(),
                  auto_release_time: int = AUTO_RELEASE_TIME,
                  num_extensions: int = NUM_EXTENSIONS,
+                 raise_on_redis_errors: bool = False,
                  ) -> None:
         super().__init__(key=key, masters=masters)
         self.__register_acquired_script()
@@ -168,6 +170,7 @@ class Redlock(Primitive):
 
         self.auto_release_time = auto_release_time
         self.num_extensions = num_extensions
+        self.raise_on_redis_errors = raise_on_redis_errors
 
         self._uuid = ''
         self._extension_num = 0
@@ -260,7 +263,10 @@ class Redlock(Primitive):
     def __drift(self) -> float:
         return self.auto_release_time * self.CLOCK_DRIFT_FACTOR + 2
 
-    def __acquire_masters(self) -> bool:
+    def __acquire_masters(self,
+                          *,
+                          raise_on_redis_errors: Optional[bool] = None,
+                          ) -> bool:
         self._uuid = str(uuid.uuid4())
         self._extension_num = 0
 
@@ -270,11 +276,12 @@ class Redlock(Primitive):
                 future = executor.submit(self.__acquire_master, master)
                 futures.add(future)
 
-            num_masters_acquired = 0
+            num_masters_acquired, redis_errors = 0, []
             for future in concurrent.futures.as_completed(futures):
                 try:
                     num_masters_acquired += future.result()
                 except RedisError as error:
+                    redis_errors.append(error)
                     _logger.exception(
                         '%s.__acquire_masters() caught %s',
                         self.__class__.__name__,
@@ -290,9 +297,22 @@ class Redlock(Primitive):
 
         with contextlib.suppress(ReleaseUnlockedLock):
             self.__release()
+        if raise_on_redis_errors is None:
+            raise_on_redis_errors = self.raise_on_redis_errors
+        if raise_on_redis_errors and len(redis_errors) > len(self.masters) // 2:
+            raise QuorumIsImpossible(
+                self.key,
+                self.masters,
+                redis_errors=redis_errors,
+            )
         return False
 
-    def acquire(self, *, blocking: bool = True, timeout: float = -1) -> bool:
+    def acquire(self,
+                *,
+                blocking: bool = True,
+                timeout: float = -1,
+                raise_on_redis_errors: Optional[bool] = None,
+                ) -> bool:
         '''Lock the lock.
 
         If blocking is True and timeout is -1, then wait for as long as
@@ -336,22 +356,26 @@ class Redlock(Primitive):
             False
             >>> printer_lock_1.release()
         '''
+        acquire_masters = functools.partial(
+            self.__acquire_masters,
+            raise_on_redis_errors=raise_on_redis_errors,
+        )
         if blocking:
             with ContextTimer() as timer:
                 while timeout == -1 or timer.elapsed() / 1000 < timeout:
-                    if self.__acquire_masters():
+                    if acquire_masters():
                         return True
                     time.sleep(random.uniform(0, self.RETRY_DELAY/1000))
             return False
 
         if timeout == -1:
-            return self.__acquire_masters()
+            return acquire_masters()
 
         raise ValueError("can't specify a timeout for a non-blocking call")
 
     __acquire = acquire
 
-    def locked(self) -> int:
+    def locked(self, *, raise_on_redis_errors: Optional[bool] = None) -> int:
         '''How much longer we'll hold the lock (unless we extend or release it).
 
         If we don't currently hold the lock, then this method returns 0.
@@ -383,11 +407,12 @@ class Redlock(Primitive):
                 future = executor.submit(self.__acquired_master, master)
                 futures.add(future)
 
-            ttls = []
+            ttls, redis_errors = [], []
             for future in concurrent.futures.as_completed(futures):
                 try:
                     ttl = future.result()
                 except RedisError as error:
+                    redis_errors.append(error)
                     _logger.exception(
                         '%s.locked() caught %s',
                         self.__class__.__name__,
@@ -402,6 +427,14 @@ class Redlock(Primitive):
                             validity_time -= timer.elapsed()
                             return max(validity_time, 0)
 
+        if raise_on_redis_errors is None:
+            raise_on_redis_errors = self.raise_on_redis_errors
+        if raise_on_redis_errors and len(redis_errors) > len(self.masters) // 2:
+            raise QuorumIsImpossible(
+                self.key,
+                self.masters,
+                redis_errors=redis_errors,
+            )
         return 0
 
     __locked = locked
@@ -433,11 +466,12 @@ class Redlock(Primitive):
                 future = executor.submit(self.__extend_master, master)
                 futures.add(future)
 
-            num_masters_extended = 0
+            num_masters_extended, redis_errors = 0, []
             for future in concurrent.futures.as_completed(futures):
                 try:
                     num_masters_extended += future.result()
                 except RedisError as error:
+                    redis_errors.append(error)
                     _logger.exception(
                         '%s.extend() caught %s',
                         self.__class__.__name__,
@@ -448,7 +482,20 @@ class Redlock(Primitive):
                         self._extension_num += 1
                         return
 
-        raise ExtendUnlockedLock(self.key, self.masters)
+        if (
+            self.raise_on_redis_errors
+            and len(redis_errors) > len(self.masters) // 2
+        ):
+            raise QuorumIsImpossible(
+                self.key,
+                self.masters,
+                redis_errors=redis_errors,
+            )
+        raise ExtendUnlockedLock(
+            self.key,
+            self.masters,
+            redis_errors=redis_errors,
+        )
 
     def release(self) -> None:
         '''Unlock the lock.
@@ -472,11 +519,12 @@ class Redlock(Primitive):
                 future = executor.submit(self.__release_master, master)
                 futures.add(future)
 
-            num_masters_released = 0
+            num_masters_released, redis_errors = 0, []
             for future in concurrent.futures.as_completed(futures):
                 try:
                     num_masters_released += future.result()
                 except RedisError as error:
+                    redis_errors.append(error)
                     _logger.exception(
                         '%s.release() caught %s',
                         self.__class__.__name__,
@@ -486,7 +534,20 @@ class Redlock(Primitive):
                     if num_masters_released > len(self.masters) // 2:
                         return
 
-        raise ReleaseUnlockedLock(self.key, self.masters)
+        if (
+            self.raise_on_redis_errors
+            and len(redis_errors) > len(self.masters) // 2
+        ):
+            raise QuorumIsImpossible(
+                self.key,
+                self.masters,
+                redis_errors=redis_errors,
+            )
+        raise ReleaseUnlockedLock(
+            self.key,
+            self.masters,
+            redis_errors=redis_errors,
+        )
 
     __release = release
 
@@ -560,8 +621,8 @@ class Redlock(Primitive):
 
     def __repr__(self) -> str:
         return (
-            f"<{self.__class__.__name__} key={self.key} "
-            f"UUID='{self._uuid}' timeout={self.__locked()}>"
+            f'<{self.__class__.__name__} key={self.key} UUID={self._uuid} '
+            f'timeout={self.__locked()}>'
         )
 
 
@@ -569,6 +630,7 @@ def synchronize(*,
                 key: str,
                 masters: Iterable[Redis] = frozenset(),
                 auto_release_time: int = AUTO_RELEASE_TIME,
+                raise_on_redis_errors: bool = False,
                 ) -> Callable[[F], F]:
     '''Decorator to synchronize a function's execution across threads.
 
@@ -593,6 +655,7 @@ def synchronize(*,
                 key=key,
                 masters=masters,
                 auto_release_time=auto_release_time,
+                raise_on_redis_errors=raise_on_redis_errors,
             )
             with ContextTimer() as timer, redlock:
                 return_value = func(*args, **kwargs)

--- a/pottery/redlock.py
+++ b/pottery/redlock.py
@@ -299,7 +299,7 @@ class Redlock(Primitive):
 
         with contextlib.suppress(ReleaseUnlockedLock):
             self.__release()
-        self._raise_on_redis_errors(raise_on_redis_errors, redis_errors)
+        self._check_enough_masters_up(raise_on_redis_errors, redis_errors)
         return False
 
     def acquire(self,
@@ -422,7 +422,7 @@ class Redlock(Primitive):
                             validity_time -= timer.elapsed()
                             return max(validity_time, 0)
 
-        self._raise_on_redis_errors(raise_on_redis_errors, redis_errors)
+        self._check_enough_masters_up(raise_on_redis_errors, redis_errors)
         return 0
 
     __locked = locked
@@ -470,7 +470,7 @@ class Redlock(Primitive):
                         self._extension_num += 1
                         return
 
-        self._raise_on_redis_errors(raise_on_redis_errors, redis_errors)
+        self._check_enough_masters_up(raise_on_redis_errors, redis_errors)
         raise ExtendUnlockedLock(
             self.key,
             self.masters,
@@ -514,7 +514,7 @@ class Redlock(Primitive):
                     if num_masters_released > len(self.masters) // 2:
                         return
 
-        self._raise_on_redis_errors(raise_on_redis_errors, redis_errors)
+        self._check_enough_masters_up(raise_on_redis_errors, redis_errors)
         raise ReleaseUnlockedLock(
             self.key,
             self.masters,

--- a/pottery/redlock.py
+++ b/pottery/redlock.py
@@ -439,7 +439,7 @@ class Redlock(Primitive):
 
     __locked = locked
 
-    def extend(self) -> None:
+    def extend(self, *, raise_on_redis_errors: Optional[bool] = None) -> None:
         '''Extend our hold on the lock (if we currently hold it).
 
         Usage:
@@ -482,10 +482,9 @@ class Redlock(Primitive):
                         self._extension_num += 1
                         return
 
-        if (
-            self.raise_on_redis_errors
-            and len(redis_errors) > len(self.masters) // 2
-        ):
+        if raise_on_redis_errors is None:
+            raise_on_redis_errors = self.raise_on_redis_errors
+        if raise_on_redis_errors and len(redis_errors) > len(self.masters) // 2:
             raise QuorumIsImpossible(
                 self.key,
                 self.masters,
@@ -497,7 +496,7 @@ class Redlock(Primitive):
             redis_errors=redis_errors,
         )
 
-    def release(self) -> None:
+    def release(self, *, raise_on_redis_errors: Optional[bool] = None) -> None:
         '''Unlock the lock.
 
         Usage:
@@ -534,10 +533,9 @@ class Redlock(Primitive):
                     if num_masters_released > len(self.masters) // 2:
                         return
 
-        if (
-            self.raise_on_redis_errors
-            and len(redis_errors) > len(self.masters) // 2
-        ):
+        if raise_on_redis_errors is None:
+            raise_on_redis_errors = self.raise_on_redis_errors
+        if raise_on_redis_errors and len(redis_errors) > len(self.masters) // 2:
             raise QuorumIsImpossible(
                 self.key,
                 self.masters,

--- a/pottery/redlock.py
+++ b/pottery/redlock.py
@@ -158,9 +158,9 @@ class Redlock(Primitive):
                  *,
                  key: str,
                  masters: Iterable[Redis] = frozenset(),
+                 raise_on_redis_errors: bool = False,
                  auto_release_time: int = AUTO_RELEASE_TIME,
                  num_extensions: int = NUM_EXTENSIONS,
-                 raise_on_redis_errors: bool = False,
                  ) -> None:
         super().__init__(
             key=key,

--- a/pottery/redlock.py
+++ b/pottery/redlock.py
@@ -298,7 +298,7 @@ class Redlock(Primitive):
                             return True
 
         with contextlib.suppress(ReleaseUnlockedLock):
-            self.__release()
+            self.__release(raise_on_redis_errors=False)
         self._check_enough_masters_up(raise_on_redis_errors, redis_errors)
         return False
 

--- a/tests/test_redlock.py
+++ b/tests/test_redlock.py
@@ -121,7 +121,8 @@ class RedlockTests(TestCase):
         except ReleaseUnlockedLock as wtf:
             assert repr(wtf) == (
                 "ReleaseUnlockedLock(key='redlock:printer', "
-                f"masters=[Redis<ConnectionPool<Connection<host=localhost,port=6379,db={self.redis_db}>>>])"
+                f"masters=[Redis<ConnectionPool<Connection<host=localhost,port=6379,db={self.redis_db}>>>], "
+                "redis_errors=[])"
             )
 
     def test_releaseunlockedlock_str(self):
@@ -130,7 +131,8 @@ class RedlockTests(TestCase):
         except ReleaseUnlockedLock as wtf:
             assert str(wtf) == (
                 "key='redlock:printer', "
-                f"masters=[Redis<ConnectionPool<Connection<host=localhost,port=6379,db={self.redis_db}>>>]"
+                f"masters=[Redis<ConnectionPool<Connection<host=localhost,port=6379,db={self.redis_db}>>>], "
+                "redis_errors=[]"
             )
 
     def test_release_same_lock_twice(self):
@@ -184,7 +186,7 @@ class RedlockTests(TestCase):
 
     def test_repr(self):
         assert repr(self.redlock) == \
-            "<Redlock key=redlock:printer UUID='' timeout=0>"
+            "<Redlock key=redlock:printer UUID= timeout=0>"
 
     def test_acquire_rediserror(self):
         with unittest.mock.patch.object(self.redis, 'set') as set:

--- a/tests/test_redlock.py
+++ b/tests/test_redlock.py
@@ -21,10 +21,11 @@ import concurrent.futures
 import time
 import unittest.mock
 
-from redis import RedisError
+from redis.exceptions import TimeoutError
 
 from pottery import ContextTimer
 from pottery import ExtendUnlockedLock
+from pottery import QuorumIsImpossible
 from pottery import Redlock
 from pottery import ReleaseUnlockedLock
 from pottery import TooManyExtensions
@@ -190,28 +191,55 @@ class RedlockTests(TestCase):
 
     def test_acquire_rediserror(self):
         with unittest.mock.patch.object(self.redis, 'set') as set:
-            set.side_effect = RedisError
+            set.side_effect = TimeoutError
             assert not self.redlock.acquire(blocking=False)
+
+    def test_acquire_quorumisimpossible(self):
+        with unittest.mock.patch.object(self.redis, 'set') as set, \
+             self.assertRaises(QuorumIsImpossible):
+            set.side_effect = TimeoutError
+            self.redlock.acquire(raise_on_redis_errors=True)
 
     def test_locked_rediserror(self):
         with self.redlock, \
              unittest.mock.patch.object(self.redlock, '_acquired_script') as _acquired_script:
-            _acquired_script.side_effect = RedisError
+            _acquired_script.side_effect = TimeoutError
             assert not self.redlock.locked()
+
+    def test_locked_quorumisimpossible(self):
+        with self.redlock, \
+             unittest.mock.patch.object(self.redlock, '_acquired_script') as _acquired_script, \
+             self.assertRaises(QuorumIsImpossible):
+            _acquired_script.side_effect = TimeoutError
+            self.redlock.locked(raise_on_redis_errors=True)
 
     def test_extend_rediserror(self):
         with self.redlock, \
              unittest.mock.patch.object(self.redlock, '_extend_script') as _extend_script, \
              self.assertRaises(ExtendUnlockedLock):
-            _extend_script.side_effect = RedisError
+            _extend_script.side_effect = TimeoutError
             self.redlock.extend()
+
+    def test_extend_quorumisimpossible(self):
+        with self.redlock, \
+             unittest.mock.patch.object(self.redlock, '_extend_script') as _extend_script, \
+             self.assertRaises(QuorumIsImpossible):
+            _extend_script.side_effect = TimeoutError
+            self.redlock.extend(raise_on_redis_errors=True)
 
     def test_release_rediserror(self):
         with self.redlock, \
              unittest.mock.patch.object(self.redlock, '_release_script') as _release_script, \
              self.assertRaises(ReleaseUnlockedLock):
-            _release_script.side_effect = RedisError
+            _release_script.side_effect = TimeoutError
             self.redlock.release()
+
+    def test_release_quorumisimpossible(self):
+        with self.redlock, \
+             unittest.mock.patch.object(self.redlock, '_release_script') as _release_script, \
+             self.assertRaises(QuorumIsImpossible):
+            _release_script.side_effect = TimeoutError
+            self.redlock.release(raise_on_redis_errors=True)
 
 
 class SynchronizeTests(TestCase):


### PR DESCRIPTION
If a majority of Redis masters are down, then attempting to acquire a
Redlock will never succeed.  Raise a new custom exception in this case.