### PR TITLE
Implement Librato-style structured log metrics

### DIFF
--- a/pottery/__init__.py
+++ b/pottery/__init__.py
@@ -30,7 +30,7 @@ from typing_extensions import Final
 
 
 __title__ = 'pottery'
-__version__ = '1.2.0'
+__version__ = '1.2.1'
 __description__, __long_description__ = (
     s.strip() for s in __doc__.split(sep='\n\n', maxsplit=1)
 )


### PR DESCRIPTION
Examples of Librato-style logging:
https://devcenter.heroku.com/articles/librato

We can use these logs to get insight into metrics like how long threads
are enqueued waiting on a Redlock.