### PR TITLE
Refactor @synchronize() decorator

### DIFF
--- a/pottery/__init__.py
+++ b/pottery/__init__.py
@@ -30,7 +30,7 @@ from typing_extensions import Final
 
 
 __title__ = 'pottery'
-__version__ = '1.3.1'
+__version__ = '1.3.2'
 __description__, __long_description__ = (
     s.strip() for s in __doc__.split(sep='\n\n', maxsplit=1)
 )


### PR DESCRIPTION
1. Use `RedlockFactory` to instantiate `Redlock`.  This reduces
   cognitive load using chunking and aliasing, and also makes the code
   safer.
2. Track and log the time `@synchronize()` spends waiting for and
   holding the `Redlock`.