### PR TITLE
Remove I/O from .__repr__()s

### DIFF
--- a/pottery/__init__.py
+++ b/pottery/__init__.py
@@ -30,7 +30,7 @@ from typing_extensions import Final
 
 
 __title__ = 'pottery'
-__version__ = '1.3.2'
+__version__ = '1.3.3'
 __description__, __long_description__ = (
     s.strip() for s in __doc__.split(sep='\n\n', maxsplit=1)
 )

--- a/pottery/nextid.py
+++ b/pottery/nextid.py
@@ -234,10 +234,7 @@ class NextId(_Scripts, Primitive):
         )
 
     def __repr__(self) -> str:
-        return (
-            f'<{self.__class__.__name__} key={self.key} '
-            f'value={self.__current_id}>'
-        )
+        return f'<{self.__class__.__name__} key={self.key}>'
 
 
 if __name__ == '__main__':

--- a/pottery/redlock.py
+++ b/pottery/redlock.py
@@ -648,10 +648,7 @@ class Redlock(_Scripts, Primitive):
         return False
 
     def __repr__(self) -> str:
-        return (
-            f'<{self.__class__.__name__} key={self.key} UUID={self._uuid} '
-            f'timeout={self.__locked()}>'
-        )
+        return f'<{self.__class__.__name__} key={self.key}>'
 
 
 def synchronize(*,

--- a/tests/test_nextid.py
+++ b/tests/test_nextid.py
@@ -47,7 +47,7 @@ class NextIdTests(TestCase):
         assert iter(self.ids) is self.ids
 
     def test_repr(self):
-        assert repr(self.ids) == '<NextId key=nextid:current value=0>'
+        assert repr(self.ids) == '<NextId key=nextid:current>'
 
     def test_slots(self):
         with self.assertRaises(AttributeError):

--- a/tests/test_redlock.py
+++ b/tests/test_redlock.py
@@ -228,8 +228,7 @@ class RedlockTests(TestCase):
                 ...
 
     def test_repr(self):
-        assert repr(self.redlock) == \
-            "<Redlock key=redlock:printer UUID= timeout=0>"
+        assert repr(self.redlock) == "<Redlock key=redlock:printer>"
 
     def test_slots(self):
         with self.assertRaises(AttributeError):


### PR DESCRIPTION
When the Redis connection pool is exhausted, the Redis client throws
`ConnectionError`s.  Then the Sentry SDK tries to record the tracebacks.
If you have a `Redlock` or a `NextId` anywhere in those tracebacks, then
the Sentry SDK calls `repr()` on those objects.  And if those objects'
`.__repr__()`s try to talk to Redis, then the client throws nested
`ConnectionError`s.

So don't talk to Redis from `Redlock.__repr__()` or `NextId.__repr__()`.