### PR TITLE
Monkey patch the Redis client to implement LOLWUT

### DIFF
--- a/pottery/__init__.py
+++ b/pottery/__init__.py
@@ -30,7 +30,7 @@ from typing_extensions import Final
 
 
 __title__ = 'pottery'
-__version__ = '1.3.3'
+__version__ = '1.3.4'
 __description__, __long_description__ = (
     s.strip() for s in __doc__.split(sep='\n\n', maxsplit=1)
 )

--- a/pottery/monkey.py
+++ b/pottery/monkey.py
@@ -46,7 +46,7 @@ def __eq__(self: ConnectionPool, other: Any) -> bool:
 ConnectionPool.__eq__ = __eq__  # type: ignore
 
 _logger.info(
-    'Monkey patched ConnectionPool.__eq__() to compare Redis clients by '
+    'Monkey patched redis.ConnectionPool.__eq__() to compare Redis clients by '
     'connection params'
 )
 
@@ -72,4 +72,25 @@ _logger.info(
     'Monkey patched json.JSONEncoder.default() to be able to JSONify any '
     'instance of any class that defines a .to_dict(), .to_list(), or .to_str() '
     'method'
+)
+
+
+# Monkey patch the Redis client to implement the LOLWUT command.
+#     1. LOLWUT command: https://redis.io/commands/lolwut
+#     2. PR upstream: https://github.com/andymccurdy/redis-py/pull/1448
+
+from redis import Redis  # isort: skip
+
+def lolwut(self: Redis, *version_numbers: int) -> bytes:
+    "Get the Redis version and a piece of generative computer art"
+    if version_numbers:
+        return self.execute_command('LOLWUT VERSION', *version_numbers)
+    else:
+        return self.execute_command('LOLWUT')
+
+Redis.lolwut = lolwut  # type: ignore
+
+_logger.info(
+    'Monkey patched redis.Redis.lolwut() to get the Redis version and a piece '
+    'of generative art'
 )

--- a/tests/test_monkey.py
+++ b/tests/test_monkey.py
@@ -30,3 +30,10 @@ class MonkeyPatchTests(TestCase):
                 "Object of type 'object' is not JSON serializable",  # Python 3.6
                 'Object of type object is not JSON serializable',    # Python 3.7+
             }
+
+    def test_redis_lolwut(self):
+        lolwut = self.redis.lolwut().decode('utf-8')
+        assert 'Redis ver.' in lolwut
+
+        lolwut = self.redis.lolwut(5, 6, 7, 8).decode('utf-8')
+        assert 'Redis ver.' in lolwut


### PR DESCRIPTION
1. `LOLWUT` command: https://redis.io/commands/lolwut
2. PR upstream: https://github.com/andymccurdy/redis-py/pull/1448