### PR TITLE
Loosen CachedOrderedDict._misses type annotation

### DIFF
--- a/pottery/cache.py
+++ b/pottery/cache.py
@@ -24,7 +24,7 @@ import logging
 from typing import Any
 from typing import Callable
 from typing import ClassVar
-from typing import FrozenSet
+from typing import Collection
 from typing import Hashable
 from typing import Iterable
 from typing import NamedTuple
@@ -254,7 +254,7 @@ class CachedOrderedDict(collections.OrderedDict):
                 items.append(item)
         return super().__init__(items)
 
-    def misses(self) -> FrozenSet[JSONTypes]:
+    def misses(self) -> Collection[JSONTypes]:
         return frozenset(self._misses)
 
     @_set_expiration

--- a/requirements.txt
+++ b/requirements.txt
@@ -29,7 +29,7 @@ toml==0.10.2
 tqdm==4.61.2
 twine==3.4.2
 types-redis==3.5.7
-typing-extensions==3.10.0.1
+typing-extensions==3.10.0.2
 urllib3==1.26.6
 webencodings==0.5.1
 zipp==3.5.0


### PR DESCRIPTION
This will allow us to change `CachedOrderedDict._misses` to be ordered
in the future if we want.