### PR TITLE
Make Pottery work for both bytes and str responses

### DIFF
--- a/pottery/__init__.py
+++ b/pottery/__init__.py
@@ -30,7 +30,7 @@ from typing_extensions import Final
 
 
 __title__ = 'pottery'
-__version__ = '1.3.5'
+__version__ = '1.3.6'
 __description__, __long_description__ = (
     s.strip() for s in __doc__.split(sep='\n\n', maxsplit=1)
 )

--- a/pottery/base.py
+++ b/pottery/base.py
@@ -28,6 +28,7 @@ import random
 import string
 from types import TracebackType
 from typing import Any
+from typing import AnyStr
 from typing import ClassVar
 from typing import ContextManager
 from typing import FrozenSet
@@ -150,8 +151,12 @@ class _Encodable:
         return encoded
 
     @staticmethod
-    def _decode(value: bytes) -> JSONTypes:
-        decoded: JSONTypes = json.loads(value.decode('utf-8'))
+    def _decode(value: AnyStr) -> JSONTypes:
+        try:
+            string = cast(bytes, value).decode('utf-8')
+        except AttributeError:
+            string = cast(str, value)
+        decoded: JSONTypes = json.loads(string)
         return decoded
 
 

--- a/pottery/monkey.py
+++ b/pottery/monkey.py
@@ -34,7 +34,7 @@ _logger: Final[logging.Logger] = logging.getLogger('pottery')
 # connection pools to be equal if they're connected to the same host, port, and
 # database.
 
-from redis import ConnectionPool  # isort:skip
+from redis import ConnectionPool  # isort: skip
 
 def __eq__(self: ConnectionPool, other: Any) -> bool:
     try:
@@ -64,7 +64,7 @@ def _default(self: Any, obj: Any) -> Union[Dict[str, Any], List[Any], str]:
     return_value: Union[Dict[str, Any], List[Any], str] = func(obj)
     return return_value
 
-import json  # isort:skip
+import json  # isort: skip
 _default.default = json.JSONEncoder().default  # type: ignore
 json.JSONEncoder.default = _default  # type: ignore
 

--- a/tests/base.py
+++ b/tests/base.py
@@ -34,9 +34,20 @@ class TestCase(unittest.TestCase):
 
     def setUp(self) -> None:
         super().setUp()
+
+        # Choose a random Redis database for this test.
         self.redis_db = random.randint(1, 15)
         url = f'redis://localhost:6379/{self.redis_db}'
+
+        # Set up our Redis clients.
         self.redis = Redis.from_url(url, socket_timeout=1)
+        self.redis_decoded_responses = Redis.from_url(
+            url,
+            socket_timeout=1,
+            decode_responses=True,
+        )
+
+        # Clean up the Redis database before and after the test.
         self.redis.flushdb()
         self.addCleanup(self.redis.flushdb)
 

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -129,6 +129,29 @@ class CommonTests(_BaseTestCase):
                 self.fail(msg='RandomKeyError not raised')
 
 
+class EncodableTests(TestCase):
+    def test_decoded_responses(self):
+        'Ensure that Pottery still works if the Redis client decodes responses.'
+        tel = RedisDict(
+            {'jack': 4098, 'sape': 4139},
+            redis=self.redis_decoded_responses,
+        )
+
+        # Ensure that repr(tel) does not raise this exception:
+        #
+        # Traceback (most recent call last):
+        #   File "/Users/rajiv.shah/Documents/Code/pottery/tests/test_base.py", line 139, in test_decoded_responses
+        #     repr(tel)
+        #   File "/Users/rajiv.shah/Documents/Code/pottery/pottery/dict.py", line 116, in __repr__
+        #     dict_ = {self._decode(key): self._decode(value) for key, value in items}
+        #   File "/Users/rajiv.shah/Documents/Code/pottery/pottery/dict.py", line 116, in <dictcomp>
+        #     dict_ = {self._decode(key): self._decode(value) for key, value in items}
+        #   File "/Users/rajiv.shah/Documents/Code/pottery/pottery/base.py", line 154, in _decode
+        #     decoded: JSONTypes = json.loads(value.decode('utf-8'))
+        # AttributeError: 'str' object has no attribute 'decode'
+        repr(tel)
+
+
 class IterableTests(TestCase):
     def test_iter(self):
         garbage = RedisDict()

--- a/tests/test_monkey.py
+++ b/tests/test_monkey.py
@@ -32,8 +32,15 @@ class MonkeyPatchTests(TestCase):
             }
 
     def test_redis_lolwut(self):
-        lolwut = self.redis.lolwut().decode('utf-8')
+        lolwut = self._lolwut()
         assert 'Redis ver.' in lolwut
 
-        lolwut = self.redis.lolwut(5, 6, 7, 8).decode('utf-8')
+        lolwut = self._lolwut(5, 6, 7, 8)
         assert 'Redis ver.' in lolwut
+
+    def _lolwut(self, *args: int) -> str:
+        response = self.redis.lolwut(*args)
+        try:
+            return response.decode('utf-8')
+        except AttributeError:  # pragma: no cover
+            return response


### PR DESCRIPTION
By default, the Redis client returns `bytes` responses.  However, the
Redis client can be configured to return `str` responses.  Make Pottery
work for either type of responses.