### PR TITLE
Implement NextId.reset()

### DIFF
--- a/pottery/__init__.py
+++ b/pottery/__init__.py
@@ -30,7 +30,7 @@ from typing_extensions import Final
 
 
 __title__ = 'pottery'
-__version__ = '1.3.6'
+__version__ = '1.4.0'
 __description__, __long_description__ = (
     s.strip() for s in __doc__.split(sep='\n\n', maxsplit=1)
 )

--- a/pottery/nextid.py
+++ b/pottery/nextid.py
@@ -238,7 +238,7 @@ class NextId(_Scripts, Primitive):
             for future in concurrent.futures.as_completed(futures):
                 try:
                     future.result()
-                except RedisError as error:  # pragma: no cover
+                except RedisError as error:
                     redis_errors.append(error)
                     _logger.exception(
                         '%s.reset() caught %s',
@@ -250,8 +250,8 @@ class NextId(_Scripts, Primitive):
                     if num_masters_reset > len(self.masters) // 2:  # pragma: no cover
                         return
 
-            self._check_enough_masters_up(None, redis_errors)  # pragma: no cover
-            raise QuorumNotAchieved(  # pragma: no cover
+            self._check_enough_masters_up(None, redis_errors)
+            raise QuorumNotAchieved(
                 self.key,
                 self.masters,
                 redis_errors=redis_errors,

--- a/pottery/nextid.py
+++ b/pottery/nextid.py
@@ -250,12 +250,12 @@ class NextId(_Scripts, Primitive):
                     if num_masters_reset > len(self.masters) // 2:  # pragma: no cover
                         return
 
-            self._check_enough_masters_up(None, redis_errors)
-            raise QuorumNotAchieved(
-                self.key,
-                self.masters,
-                redis_errors=redis_errors,
-            )
+        self._check_enough_masters_up(None, redis_errors)
+        raise QuorumNotAchieved(
+            self.key,
+            self.masters,
+            redis_errors=redis_errors,
+        )
 
     def __repr__(self) -> str:
         return f'<{self.__class__.__name__} key={self.key}>'

--- a/pottery/nextid.py
+++ b/pottery/nextid.py
@@ -227,6 +227,36 @@ class NextId(_Scripts, Primitive):
             redis_errors=redis_errors,
         )
 
+    def reset(self) -> None:
+        with BailOutExecutor() as executor:
+            futures = set()
+            for master in self.masters:
+                future = executor.submit(master.delete, self.key)
+                futures.add(future)
+
+            num_masters_reset, redis_errors = 0, []
+            for future in concurrent.futures.as_completed(futures):
+                try:
+                    future.result()
+                except RedisError as error:  # pragma: no cover
+                    redis_errors.append(error)
+                    _logger.exception(
+                        '%s.reset() caught %s',
+                        self.__class__.__name__,
+                        error.__class__.__name__,
+                    )
+                else:
+                    num_masters_reset += 1
+                    if num_masters_reset > len(self.masters) // 2:  # pragma: no cover
+                        return
+
+            self._check_enough_masters_up(None, redis_errors)  # pragma: no cover
+            raise QuorumNotAchieved(  # pragma: no cover
+                self.key,
+                self.masters,
+                redis_errors=redis_errors,
+            )
+
     def __repr__(self) -> str:
         return f'<{self.__class__.__name__} key={self.key}>'
 

--- a/tests/test_nextid.py
+++ b/tests/test_nextid.py
@@ -82,3 +82,10 @@ class NextIdTests(TestCase):
              unittest.mock.patch.object(Script, '__call__') as __call__:
             __call__.side_effect = TimeoutError
             next(self.ids)
+
+    def test_reset(self):
+        next(self.ids)
+        assert self.redis.exists(self.ids.key)
+
+        self.ids.reset()
+        assert not self.redis.exists(self.ids.key)

--- a/tests/test_nextid.py
+++ b/tests/test_nextid.py
@@ -47,11 +47,17 @@ class NextIdTests(TestCase):
         assert iter(self.ids) is self.ids
 
     def test_reset(self):
-        next(self.ids)
+        self.ids.reset()
+        assert not self.redis.exists(self.ids.key)
+
+        assert next(self.ids) == 1
         assert self.redis.exists(self.ids.key)
 
         self.ids.reset()
         assert not self.redis.exists(self.ids.key)
+
+        assert next(self.ids) == 1
+        assert self.redis.exists(self.ids.key)
 
     def test_repr(self):
         assert repr(self.ids) == '<NextId key=nextid:current>'

--- a/tests/test_nextid.py
+++ b/tests/test_nextid.py
@@ -89,3 +89,23 @@ class NextIdTests(TestCase):
              unittest.mock.patch.object(Script, '__call__') as __call__:
             __call__.side_effect = TimeoutError
             next(self.ids)
+
+    def test_reset_quorumnotachieved(self):
+        with self.assertRaises(QuorumNotAchieved), \
+             unittest.mock.patch.object(
+                 next(iter(self.ids.masters)),
+                 'delete',
+             ) as delete:
+            delete.side_effect = TimeoutError
+            self.ids.reset()
+
+    def test_reset_quorumisimpossible(self):
+        self.ids = NextId(masters={self.redis}, raise_on_redis_errors=True)
+
+        with self.assertRaises(QuorumIsImpossible), \
+             unittest.mock.patch.object(
+                 next(iter(self.ids.masters)),
+                 'delete',
+             ) as delete:
+            delete.side_effect = TimeoutError
+            self.ids.reset()

--- a/tests/test_nextid.py
+++ b/tests/test_nextid.py
@@ -46,6 +46,13 @@ class NextIdTests(TestCase):
     def test_iter(self):
         assert iter(self.ids) is self.ids
 
+    def test_reset(self):
+        next(self.ids)
+        assert self.redis.exists(self.ids.key)
+
+        self.ids.reset()
+        assert not self.redis.exists(self.ids.key)
+
     def test_repr(self):
         assert repr(self.ids) == '<NextId key=nextid:current>'
 
@@ -82,10 +89,3 @@ class NextIdTests(TestCase):
              unittest.mock.patch.object(Script, '__call__') as __call__:
             __call__.side_effect = TimeoutError
             next(self.ids)
-
-    def test_reset(self):
-        next(self.ids)
-        assert self.redis.exists(self.ids.key)
-
-        self.ids.reset()
-        assert not self.redis.exists(self.ids.key)


### PR DESCRIPTION
`NextId.reset()` deletes the `NextId` object's key from the Redis
masters, in effect resetting the current ID to 0.