### PR TITLE
In NextId getter, bail out when quorum achieved

### DIFF
--- a/pottery/__init__.py
+++ b/pottery/__init__.py
@@ -30,7 +30,7 @@ from typing_extensions import Final
 
 
 __title__ = 'pottery'
-__version__ = '1.4.0'
+__version__ = '1.4.1'
 __description__, __long_description__ = (
     s.strip() for s in __doc__.split(sep='\n\n', maxsplit=1)
 )


### PR DESCRIPTION
To get the current ID, we don't need to interrogate all Redis masters.
We just need to hit a majority of Redis masters, then return the highest
ID.