### PR TITLE
Make consensus-based read ops more efficient

### DIFF
--- a/pottery/nextid.py
+++ b/pottery/nextid.py
@@ -167,7 +167,7 @@ class NextId(_Scripts, Primitive):
 
     @property
     def __current_id(self) -> int:
-        with BailOutExecutor() as executor:
+        with concurrent.futures.ThreadPoolExecutor() as executor:
             futures = set()
             for master in self.masters:
                 future = executor.submit(master.get, self.key)

--- a/pottery/redlock.py
+++ b/pottery/redlock.py
@@ -453,7 +453,8 @@ class Redlock(_Scripts, Primitive):
             >>> printer_lock_1.release()
 
         '''
-        with ContextTimer() as timer, BailOutExecutor() as executor:
+        with ContextTimer() as timer, \
+             concurrent.futures.ThreadPoolExecutor() as executor:
             futures = set()
             for master in self.masters:
                 future = executor.submit(self.__acquired_master, master)


### PR DESCRIPTION
On read operations, once we've achieved quorum and read the value that
we need, cancel pending in-flight futures.