### PR TITLE
In NextId.reset(), reset all Redis masters

### DIFF
--- a/pottery/__init__.py
+++ b/pottery/__init__.py
@@ -30,7 +30,7 @@ from typing_extensions import Final
 
 
 __title__ = 'pottery'
-__version__ = '1.4.1'
+__version__ = '1.4.2'
 __description__, __long_description__ = (
     s.strip() for s in __doc__.split(sep='\n\n', maxsplit=1)
 )

--- a/pottery/nextid.py
+++ b/pottery/nextid.py
@@ -233,7 +233,7 @@ class NextId(_Scripts, Primitive):
 
     def reset(self) -> None:
         'Reset the ID counter to 0.'
-        with BailOutExecutor() as executor:
+        with concurrent.futures.ThreadPoolExecutor() as executor:
             futures = set()
             for master in self.masters:
                 future = executor.submit(master.delete, self.key)
@@ -252,7 +252,7 @@ class NextId(_Scripts, Primitive):
                     )
                 else:
                     num_masters_reset += 1
-                    if num_masters_reset > len(self.masters) // 2:  # pragma: no cover
+                    if num_masters_reset == len(self.masters):  # pragma: no cover
                         return
 
         self._check_enough_masters_up(None, redis_errors)

--- a/requirements.txt
+++ b/requirements.txt
@@ -28,7 +28,7 @@ six==1.16.0
 toml==0.10.2
 tqdm==4.61.2
 twine==3.4.2
-types-redis==3.5.8
+types-redis==3.5.9
 typing-extensions==3.10.0.2
 urllib3==1.26.7
 webencodings==0.5.1


### PR DESCRIPTION
Previously, I'd modified the `NextId.__current_id` getter to get the ID
from `n // 2 + 1` Redis masters, then to return the highest of those
IDs.

This means that `NextId.reset()` must delete the Redis key from all
masters.