### PR TITLE
Use BailOutExecutor in more places

### DIFF
--- a/pottery/__init__.py
+++ b/pottery/__init__.py
@@ -30,7 +30,7 @@ from typing_extensions import Final
 
 
 __title__ = 'pottery'
-__version__ = '1.4.5'
+__version__ = '1.4.6'
 __description__ = __doc__.split(sep='\n\n', maxsplit=1)[0]
 __url__ = 'https://github.com/brainix/pottery'
 __author__ = 'Rajiv Bakulesh Shah'

--- a/pottery/nextid.py
+++ b/pottery/nextid.py
@@ -167,7 +167,7 @@ class NextId(_Scripts, Primitive):
 
     @property
     def __current_id(self) -> int:
-        with concurrent.futures.ThreadPoolExecutor() as executor:
+        with BailOutExecutor() as executor:
             futures = set()
             for master in self.masters:
                 future = executor.submit(master.get, self.key)

--- a/pottery/redlock.py
+++ b/pottery/redlock.py
@@ -453,8 +453,7 @@ class Redlock(_Scripts, Primitive):
             >>> printer_lock_1.release()
 
         '''
-        with ContextTimer() as timer, \
-             concurrent.futures.ThreadPoolExecutor() as executor:
+        with ContextTimer() as timer, BailOutExecutor() as executor:
             futures = set()
             for master in self.masters:
                 future = executor.submit(self.__acquired_master, master)


### PR DESCRIPTION
This makes `Redlock.locked()` and the `NextId.__current_id` getter more
efficient for several masters.