### PR TITLE
Implement HyperLogLog.__contains__()

### DIFF
--- a/pottery/exceptions.py
+++ b/pottery/exceptions.py
@@ -102,3 +102,6 @@ class PotteryWarning(Warning):
 
 class InefficientAccessWarning(PotteryWarning):
     'Doing an O(n) Redis operation.'
+
+class InaccurateAlgorithmWarning(PotteryWarning):
+    'Using a highly inaccurate algorithm.'

--- a/pottery/hyper.py
+++ b/pottery/hyper.py
@@ -118,9 +118,9 @@ class HyperLogLog(Base):
         if not self.redis.copy(self.key, tmp_hll_key):  # type: ignore
             return False
         encoded_value = self._encode(value)
-        registers_altered = self.redis.pfadd(tmp_hll_key, encoded_value)
+        cardinality_changed = self.redis.pfadd(tmp_hll_key, encoded_value)
         self.redis.delete(tmp_hll_key)
-        return not registers_altered
+        return not cardinality_changed
 
     def __repr__(self) -> str:
         'Return the string representation of the HyperLogLog.  O(1)'

--- a/pottery/hyper.py
+++ b/pottery/hyper.py
@@ -27,6 +27,7 @@ from redis import Redis
 from .annotations import RedisValues
 from .base import Base
 from .base import JSONTypes
+from .base import random_key
 
 
 class HyperLogLog(Base):
@@ -104,6 +105,16 @@ class HyperLogLog(Base):
         financial systems or cat gif websites.
         '''
         return self.redis.pfcount(self.key)
+
+    def __contains__(self, value: JSONTypes) -> bool:
+        'hll.__contains__(element) <==> element in hll.  O(1)'
+        tmp_hll_key = random_key(redis=self.redis)
+        if not self.redis.copy(self.key, tmp_hll_key):  # type: ignore
+            return False
+        encoded_value = self._encode(value)
+        modified = self.redis.pfadd(tmp_hll_key, encoded_value)
+        self.redis.delete(tmp_hll_key)
+        return not modified
 
     def __repr__(self) -> str:
         'Return the string representation of the HyperLogLog.  O(1)'

--- a/pottery/hyper.py
+++ b/pottery/hyper.py
@@ -16,6 +16,7 @@
 # --------------------------------------------------------------------------- #
 
 
+import warnings
 from typing import Iterable
 from typing import List
 from typing import Optional
@@ -28,6 +29,7 @@ from .annotations import RedisValues
 from .base import Base
 from .base import JSONTypes
 from .base import random_key
+from .exceptions import InaccurateAlgorithmWarning
 
 
 class HyperLogLog(Base):
@@ -108,13 +110,17 @@ class HyperLogLog(Base):
 
     def __contains__(self, value: JSONTypes) -> bool:
         'hll.__contains__(element) <==> element in hll.  O(1)'
+        warnings.warn(
+            cast(str, InaccurateAlgorithmWarning.__doc__),
+            InaccurateAlgorithmWarning,
+        )
         tmp_hll_key = random_key(redis=self.redis)
         if not self.redis.copy(self.key, tmp_hll_key):  # type: ignore
             return False
         encoded_value = self._encode(value)
-        modified = self.redis.pfadd(tmp_hll_key, encoded_value)
+        registers_altered = self.redis.pfadd(tmp_hll_key, encoded_value)
         self.redis.delete(tmp_hll_key)
-        return not modified
+        return not registers_altered
 
     def __repr__(self) -> str:
         'Return the string representation of the HyperLogLog.  O(1)'

--- a/tests/test_hyper.py
+++ b/tests/test_hyper.py
@@ -86,6 +86,21 @@ class HyperLogLogTests(TestCase):
         assert len(hll1.union({'b', 'c', 'd', 'foo'}, redis=self.redis)) == 7
         assert len(hll1.union(hll2, {'b', 'c', 'd', 'baz'}, redis=self.redis)) == 8
 
+    def test_contains(self):
+        empty_hll = HyperLogLog(redis=self.redis)
+        for letter in {'a', 'b', 'c', 'd', 'e'}:
+            with self.subTest(letter=letter):
+                assert letter not in empty_hll
+
+        metasyntactic_variables = HyperLogLog({'foo', 'bar', 'zap', 'a'}, redis=self.redis)
+        for metasyntactic_variable in {'foo', 'bar'}:
+            with self.subTest(metasyntactic_variable=metasyntactic_variable):
+                assert metasyntactic_variable in metasyntactic_variables
+
+        for metasyntactic_variable in {'baz', 'qux'}:
+            with self.subTest(metasyntactic_variable=metasyntactic_variable):
+                assert metasyntactic_variable not in metasyntactic_variables
+
     def test_repr(self):
         'Test HyperLogLog.__repr__()'
         hll = HyperLogLog(

--- a/tests/test_hyper.py
+++ b/tests/test_hyper.py
@@ -87,11 +87,6 @@ class HyperLogLogTests(TestCase):
         assert len(hll1.union(hll2, {'b', 'c', 'd', 'baz'}, redis=self.redis)) == 8
 
     def test_contains(self):
-        empty_hll = HyperLogLog(redis=self.redis)
-        for letter in {'a', 'b', 'c', 'd', 'e'}:
-            with self.subTest(letter=letter):
-                assert letter not in empty_hll
-
         metasyntactic_variables = HyperLogLog({'foo', 'bar', 'zap', 'a'}, redis=self.redis)
         for metasyntactic_variable in {'foo', 'bar'}:
             with self.subTest(metasyntactic_variable=metasyntactic_variable):


### PR DESCRIPTION
As a side effect, Redis's `PFADD` command returns whether any HLL registers were altered. As a hack, we can copy an HLL, add an element to the copy, and see if any registers were altered. If so,  the original HLL didn't contain the element.

In my testing, this technique is highly inaccurate. But I thought it'd be fun to implement anyway.

Inspired by [DEVcember weekend 2](https://github.com/redis-developer/devcember/pull/5/files#diff-c32da5a243746f642569ee969d4c3446c8da7ee0f3c990596bdc26bfc7f6475aR97-R104).