### PR TITLE
Delete inaccurate warning

### DIFF
--- a/pottery/exceptions.py
+++ b/pottery/exceptions.py
@@ -102,6 +102,3 @@ class PotteryWarning(Warning):
 
 class InefficientAccessWarning(PotteryWarning):
     'Doing an O(n) Redis operation.'
-
-class InaccurateAlgorithmWarning(PotteryWarning):
-    'Using a highly inaccurate algorithm.'

--- a/pottery/hyper.py
+++ b/pottery/hyper.py
@@ -16,7 +16,6 @@
 # --------------------------------------------------------------------------- #
 
 
-import warnings
 from typing import Iterable
 from typing import List
 from typing import Optional
@@ -29,7 +28,6 @@ from .annotations import RedisValues
 from .base import Base
 from .base import JSONTypes
 from .base import random_key
-from .exceptions import InaccurateAlgorithmWarning
 
 
 class HyperLogLog(Base):
@@ -110,10 +108,6 @@ class HyperLogLog(Base):
 
     def __contains__(self, value: JSONTypes) -> bool:
         'hll.__contains__(element) <==> element in hll.  O(1)'
-        warnings.warn(
-            cast(str, InaccurateAlgorithmWarning.__doc__),
-            InaccurateAlgorithmWarning,
-        )
         tmp_hll_key = random_key(redis=self.redis)
         if not self.redis.copy(self.key, tmp_hll_key):  # type: ignore
             return False


### PR DESCRIPTION
Upon further testing, I've learned that the `PFADD` method of
HyperLogLog membership testing is quite accurate:

https://github.com/redis-developer/devcember/pull/5/files#diff-c32da5a243746f642569ee969d4c3446c8da7ee0f3c990596bdc26bfc7f6475aR11