### PR TITLE
Implement HyperLogLog.contains_many()

### DIFF
--- a/pottery/hyper.py
+++ b/pottery/hyper.py
@@ -109,7 +109,7 @@ class HyperLogLog(Base):
 
     def __contains__(self, value: JSONTypes) -> bool:
         'hll.__contains__(element) <==> element in hll.  O(1)'
-        return next(self.contains_many(value))
+        return next(self.__contains_many(value))
 
     def contains_many(self, *values: JSONTypes) -> Generator[bool, None, None]:
         tmp_hll_key = random_key(redis=self.redis)
@@ -122,6 +122,8 @@ class HyperLogLog(Base):
         self.redis.delete(tmp_hll_key)
         for cardinality_changed in cardinalities_changed:
             yield not cardinality_changed
+
+    __contains_many = contains_many
 
     def __repr__(self) -> str:
         'Return the string representation of the HyperLogLog.  O(1)'

--- a/pottery/hyper.py
+++ b/pottery/hyper.py
@@ -109,12 +109,7 @@ class HyperLogLog(Base):
 
     def __contains__(self, value: JSONTypes) -> bool:
         'hll.__contains__(element) <==> element in hll.  O(1)'
-        tmp_hll_key = random_key(redis=self.redis)
-        self.redis.copy(self.key, tmp_hll_key)  # type: ignore
-        encoded_value = self._encode(value)
-        cardinality_changed = self.redis.pfadd(tmp_hll_key, encoded_value)
-        self.redis.delete(tmp_hll_key)
-        return not cardinality_changed
+        return next(self.contains_many(value))
 
     def contains_many(self, *values: JSONTypes) -> Generator[bool, None, None]:
         tmp_hll_key = random_key(redis=self.redis)

--- a/tests/test_hyper.py
+++ b/tests/test_hyper.py
@@ -96,6 +96,11 @@ class HyperLogLogTests(TestCase):
             with self.subTest(metasyntactic_variable=metasyntactic_variable):
                 assert metasyntactic_variable not in metasyntactic_variables
 
+    def test_contains_many(self):
+        metasyntactic_variables = HyperLogLog({'foo', 'bar', 'zap', 'a'}, redis=self.redis)
+        contains_many = metasyntactic_variables.contains_many('foo', 'bar', 'baz', 'quz')
+        assert tuple(contains_many) == (True, True, False, False)
+
     def test_repr(self):
         'Test HyperLogLog.__repr__()'
         hll = HyperLogLog(


### PR DESCRIPTION
`.contains_many()` is like `.__contains__()`, but it's better for fast
membership testing for multiple elements.