### PR TITLE
Make HyperLogLog membership testing more robust

### DIFF
--- a/pottery/hyper.py
+++ b/pottery/hyper.py
@@ -125,6 +125,8 @@ class HyperLogLog(Base):
                 try:
                     encoded_value = self._encode(value)
                 except TypeError:
+                    # value can't be encoded / converted to JSON.  Do a
+                    # membership test for a UUID in place of value.
                     uuid_ = str(uuid.uuid4())
                     encoded_value = self._encode(uuid_)
                 encoded_values.append(encoded_value)

--- a/tests/test_hyper.py
+++ b/tests/test_hyper.py
@@ -113,6 +113,10 @@ class HyperLogLogTests(TestCase):
         num_contained = sum(uuid_hll.contains_many(*uuid_list))
         assert num_contained == NUM_ELEMENTS
 
+    def test_membership_for_non_jsonifyable_element(self):
+        hll = HyperLogLog(redis=self.redis, key=self._KEY)
+        assert not BaseException in hll
+
     def test_repr(self):
         'Test HyperLogLog.__repr__()'
         hll = HyperLogLog(


### PR DESCRIPTION
With this change, `.__contains__()` and `.contains_many()` work for non-
JSONifyable values.