### PR TITLE
Delete HyperLogLog.contains_many()

### DIFF
--- a/README.md
+++ b/README.md
@@ -878,13 +878,8 @@ then the element must not have been in the original `HyperLogLog`.
 True
 >>> 'jennifer aniston' in google_searches
 False
->>> tuple(google_searches.contains_many('joey tribbiani', 'jennifer aniston'))
-(True, False)
 >>>
 ```
-
-Tip: Use `.contains_many()` to do efficient membership testing for multiple
-elements.
 
 Remove all of the elements from the `HyperLogLog`:
 

--- a/pottery/hyper.py
+++ b/pottery/hyper.py
@@ -16,9 +16,6 @@
 # --------------------------------------------------------------------------- #
 
 
-import contextlib
-import uuid
-from typing import Generator
 from typing import Iterable
 from typing import List
 from typing import Optional
@@ -111,46 +108,18 @@ class HyperLogLog(Base):
 
     def __contains__(self, value: JSONTypes) -> bool:
         'hll.__contains__(element) <==> element in hll.  O(1)'
-        return next(self.__contains_many(value))
-
-    def contains_many(self, *values: JSONTypes) -> Generator[bool, None, None]:
-        'Yield whether this HyperLogLog contains multiple elements.  O(n)'
-        # Create a temporary copy of this HyperLogLog:
-        with self.__tmp_key() as (pipeline, tmp_key):
-            # Insert the encoded elements one by one into the temporary
-            # HyperLogLog:
-            pipeline.multi()
-            for encoded_value in self.__encode_many(*values):
-                pipeline.pfadd(tmp_key, encoded_value)
-            cardinalities_changed = pipeline.execute()
-
-        # After each insertion, if the cardinality of the temporary HyperLogLog
-        # changed, then the element must not have been in this HyperLogLog.
-        for cardinality_changed in cardinalities_changed:
-            yield not cardinality_changed
-
-    __contains_many = contains_many
-
-    @contextlib.contextmanager
-    def __tmp_key(self):
-        # Create a yield a tmp copy of this HLL; finally, delete the tmp HLL.
         try:
-            with self._watch() as pipeline:
-                tmp_key = random_key(redis=pipeline)
-                pipeline.copy(self.key, tmp_key)  # type: ignore
-                yield pipeline, tmp_key
-        finally:
-            self.redis.delete(tmp_key)
+            encoded_value = self._encode(value)
+        except TypeError:
+            return False
 
-    def __encode_many(self, *values: JSONTypes) -> Generator[str, None, None]:
-        for value in values:
-            try:
-                yield self._encode(value)
-            except TypeError:
-                # value can't be encoded / converted to JSON.  Do a membership
-                # test for a UUID in place of value.
-                uuid_ = str(uuid.uuid4())
-                yield self._encode(uuid_)
+        tmp_hll_key = random_key(redis=self.redis)
+        self.redis.copy(self.key, tmp_hll_key)  # type: ignore
+        try:
+            cardinality_changed = self.redis.pfadd(tmp_hll_key, encoded_value)
+            return not cardinality_changed
+        finally:
+            self.redis.delete(tmp_hll_key)
 
     def __repr__(self) -> str:
         'Return the string representation of the HyperLogLog.  O(1)'

--- a/pottery/hyper.py
+++ b/pottery/hyper.py
@@ -16,6 +16,8 @@
 # --------------------------------------------------------------------------- #
 
 
+import logging
+from typing import Final
 from typing import Iterable
 from typing import List
 from typing import Optional
@@ -28,6 +30,9 @@ from .annotations import RedisValues
 from .base import Base
 from .base import JSONTypes
 from .base import random_key
+
+
+_logger: Final[logging.Logger] = logging.getLogger('pottery')
 
 
 class HyperLogLog(Base):
@@ -115,11 +120,19 @@ class HyperLogLog(Base):
 
         tmp_hll_key = random_key(redis=self.redis)
         self.redis.copy(self.key, tmp_hll_key)  # type: ignore
+        _logger.debug(
+            'Created tmp HyperLogLog %s (for membership testing)',
+            tmp_hll_key,
+        )
         try:
             cardinality_changed = self.redis.pfadd(tmp_hll_key, encoded_value)
             return not cardinality_changed
         finally:
             self.redis.delete(tmp_hll_key)
+            _logger.debug(
+                'Deleted tmp HyperLogLog %s (for membership testing)',
+                tmp_hll_key,
+            )
 
     def __repr__(self) -> str:
         'Return the string representation of the HyperLogLog.  O(1)'

--- a/pottery/hyper.py
+++ b/pottery/hyper.py
@@ -17,7 +17,6 @@
 
 
 import logging
-from typing import Final
 from typing import Iterable
 from typing import List
 from typing import Optional
@@ -25,6 +24,7 @@ from typing import Union
 from typing import cast
 
 from redis import Redis
+from typing_extensions import Final
 
 from .annotations import RedisValues
 from .base import Base

--- a/pottery/hyper.py
+++ b/pottery/hyper.py
@@ -16,7 +16,6 @@
 # --------------------------------------------------------------------------- #
 
 
-import logging
 from typing import Iterable
 from typing import List
 from typing import Optional
@@ -24,15 +23,11 @@ from typing import Union
 from typing import cast
 
 from redis import Redis
-from typing_extensions import Final
 
 from .annotations import RedisValues
 from .base import Base
 from .base import JSONTypes
 from .base import random_key
-
-
-_logger: Final[logging.Logger] = logging.getLogger('pottery')
 
 
 class HyperLogLog(Base):
@@ -118,21 +113,14 @@ class HyperLogLog(Base):
         except TypeError:
             return False
 
-        tmp_hll_key = random_key(redis=self.redis)
-        self.redis.copy(self.key, tmp_hll_key)  # type: ignore
-        _logger.debug(
-            'Created tmp HyperLogLog %s (for membership testing)',
-            tmp_hll_key,
-        )
-        try:
-            cardinality_changed = self.redis.pfadd(tmp_hll_key, encoded_value)
+        with self._watch() as pipeline:
+            tmp_hll_key = random_key(redis=pipeline)
+            pipeline.copy(self.key, tmp_hll_key)  # type: ignore
+            pipeline.multi()
+            pipeline.pfadd(tmp_hll_key, encoded_value)
+            pipeline.delete(tmp_hll_key)
+            cardinality_changed = pipeline.execute()[0]
             return not cardinality_changed
-        finally:
-            self.redis.delete(tmp_hll_key)
-            _logger.debug(
-                'Deleted tmp HyperLogLog %s (for membership testing)',
-                tmp_hll_key,
-            )
 
     def __repr__(self) -> str:
         'Return the string representation of the HyperLogLog.  O(1)'

--- a/tests/test_hyper.py
+++ b/tests/test_hyper.py
@@ -16,8 +16,6 @@
 # --------------------------------------------------------------------------- #
 
 
-import uuid
-
 from redis import Redis
 
 from pottery import HyperLogLog
@@ -97,21 +95,6 @@ class HyperLogLogTests(TestCase):
         for metasyntactic_variable in {'baz', 'qux'}:
             with self.subTest(metasyntactic_variable=metasyntactic_variable):
                 assert metasyntactic_variable not in metasyntactic_variables
-
-    def test_contains_many_metasyntactic_variables(self):
-        metasyntactic_variables = HyperLogLog({'foo', 'bar', 'zap', 'a'}, redis=self.redis)
-        contains_many = metasyntactic_variables.contains_many('foo', 'bar', 'baz', 'quz')
-        assert tuple(contains_many) == (True, True, False, False)
-
-    def test_contains_many_uuids(self):
-        NUM_ELEMENTS = 5000
-        uuid_list = []
-        for _ in range(NUM_ELEMENTS):
-            uuid_ = str(uuid.uuid4())
-            uuid_list.append(uuid_)
-        uuid_hll = HyperLogLog(uuid_list, redis=self.redis)
-        num_contained = sum(uuid_hll.contains_many(*uuid_list))
-        assert num_contained == NUM_ELEMENTS
 
     def test_membership_for_non_jsonifyable_element(self):
         hll = HyperLogLog(redis=self.redis, key=self._KEY)


### PR DESCRIPTION
This "feature" was buggy and misleading. It only produced correct
results up until the first missing element.