### PR TITLE
Postpone evaluation of annotations

### DIFF
--- a/pottery/counter.py
+++ b/pottery/counter.py
@@ -16,6 +16,13 @@
 # --------------------------------------------------------------------------- #
 
 
+# TODO: Remove the following import after deferred evaluation of annotations
+# because the default.
+#   1. https://docs.python.org/3/whatsnew/3.7.html#whatsnew37-pep563
+#   2. https://www.python.org/dev/peps/pep-0563/
+#   3. https://www.python.org/dev/peps/pep-0649/
+from __future__ import annotations
+
 import collections
 import contextlib
 import itertools
@@ -174,7 +181,7 @@ class RedisCounter(RedisDict, collections.Counter):
                    other: Counter[JSONTypes],
                    *,
                    sign: int = +1,
-                   ) -> 'RedisCounter':
+                   ) -> RedisCounter:
         with self._watch(other) as pipeline:
             try:
                 other_items = cast('RedisCounter', other)._make_counter().items()
@@ -209,7 +216,7 @@ class RedisCounter(RedisDict, collections.Counter):
                   other: Counter[JSONTypes],
                   *,
                   method: Callable[[int, int], bool],
-                  ) -> 'RedisCounter':
+                  ) -> RedisCounter:
         with self._watch(other) as pipeline:
             self_counter = self.__make_counter()
             try:

--- a/pottery/hyper.py
+++ b/pottery/hyper.py
@@ -16,6 +16,13 @@
 # --------------------------------------------------------------------------- #
 
 
+# TODO: Remove the following import after deferred evaluation of annotations
+# because the default.
+#   1. https://docs.python.org/3/whatsnew/3.7.html#whatsnew37-pep563
+#   2. https://www.python.org/dev/peps/pep-0563/
+#   3. https://www.python.org/dev/peps/pep-0649/
+from __future__ import annotations
+
 import uuid
 from typing import Generator
 from typing import Iterable
@@ -64,7 +71,7 @@ class HyperLogLog(Base):
         self.__update({value})
 
     def update(self,
-               *objs: Union['HyperLogLog', Iterable[RedisValues]],
+               *objs: Union[HyperLogLog, Iterable[RedisValues]],
                ) -> None:
         other_hll_keys: List[str] = []
         encoded_values: List[str] = []
@@ -94,7 +101,7 @@ class HyperLogLog(Base):
               *objs: Iterable[RedisValues],
               redis: Optional[Redis] = None,
               key: Optional[str] = None,
-              ) -> 'HyperLogLog':
+              ) -> HyperLogLog:
         new_hll = self.__class__(redis=redis, key=key)
         new_hll.update(self, *objs)
         return new_hll

--- a/pottery/list.py
+++ b/pottery/list.py
@@ -16,6 +16,13 @@
 # --------------------------------------------------------------------------- #
 
 
+# TODO: Remove the following import after deferred evaluation of annotations
+# because the default.
+#   1. https://docs.python.org/3/whatsnew/3.7.html#whatsnew37-pep563
+#   2. https://www.python.org/dev/peps/pep-0563/
+#   3. https://www.python.org/dev/peps/pep-0649/
+from __future__ import annotations
+
 import collections.abc
 import functools
 import itertools
@@ -299,7 +306,7 @@ class RedisList(Base, collections.abc.MutableSequence):
         # collection.
         return False
 
-    def __add__(self, other: List[JSONTypes]) -> 'RedisList':
+    def __add__(self, other: List[JSONTypes]) -> RedisList:
         'Append the items in other to the RedisList.  O(n)'
         warnings.warn(
             cast(str, InefficientAccessWarning.__doc__),


### PR DESCRIPTION
We recently dropped support for Python 3.6, and postponed evaluation of
annotations is a new Python 3.7 feature. This allows for cleaner type
annotations.

https://docs.python.org/3/whatsnew/3.7.html#pep-563-postponed-evaluation-of-annotations