### PR TITLE
Reorder methods in Primitive ABC to help subclass

### DIFF
--- a/pottery/base.py
+++ b/pottery/base.py
@@ -325,6 +325,11 @@ class Primitive(metaclass=abc.ABCMeta):
 
     _DEFAULT_MASTERS: ClassVar[FrozenSet[Redis]] = frozenset({_default_redis})
 
+    @property
+    @abc.abstractmethod
+    def KEY_PREFIX(self) -> str:
+        'Redis key prefix/namespace.'
+
     def __init__(self,
                  *,
                  key: str,
@@ -334,11 +339,6 @@ class Primitive(metaclass=abc.ABCMeta):
         self.key = key
         self.masters = frozenset(masters) or self._DEFAULT_MASTERS
         self.raise_on_redis_errors = raise_on_redis_errors
-
-    @property
-    @abc.abstractmethod
-    def KEY_PREFIX(self) -> str:
-        'Redis key prefix/namespace.'
 
     @property
     def key(self) -> str:

--- a/pottery/base.py
+++ b/pottery/base.py
@@ -321,14 +321,14 @@ class Iterable_(metaclass=abc.ABCMeta):
 class Primitive(metaclass=abc.ABCMeta):
     'Base class for Redis-backed distributed primitives.'
 
-    __slots__ = ('_key', 'masters', 'raise_on_redis_errors')
-
-    _DEFAULT_MASTERS: ClassVar[FrozenSet[Redis]] = frozenset({_default_redis})
-
     @property
     @abc.abstractmethod
     def KEY_PREFIX(self) -> str:
         'Redis key prefix/namespace.'
+
+    __slots__ = ('_key', 'masters', 'raise_on_redis_errors')
+
+    _DEFAULT_MASTERS: ClassVar[FrozenSet[Redis]] = frozenset({_default_redis})
 
     def __init__(self,
                  *,


### PR DESCRIPTION
Keep the abstract method at the top to make it more obvious how to
subclass.