### PR TITLE
Use redis-py's .hscan_iter() and .sscan_iter()

### DIFF
--- a/pottery/base.py
+++ b/pottery/base.py
@@ -290,32 +290,9 @@ class Base(_Common, _Encodable, _Clearable, _Pipelined, _Comparable):
 class Iterable_(metaclass=abc.ABCMeta):
     'Mixin class that implements iterating over a Redis-backed collection.'
 
-    @staticmethod
     @abc.abstractmethod
-    def _decode(value: bytes) -> JSONTypes:
-        raise NotImplementedError
-
-    @property
-    @abc.abstractmethod
-    def key(self) -> str:
-        'Redis key.'
-        raise NotImplementedError
-
-    @abc.abstractmethod
-    def _scan(self,
-              *,
-              cursor: int = 0,
-              ) -> Tuple[int, Union[List[bytes], Mapping[bytes, bytes]]]:
-        raise NotImplementedError
-
     def __iter__(self) -> Generator[JSONTypes, None, None]:
-        'Iterate over the items in a Redis-backed container.  O(n)'
-        cursor = 0
-        while True:
-            cursor, iterable = self._scan(cursor=cursor)
-            yield from (self._decode(value) for value in iterable)
-            if cursor == 0:
-                break
+        raise NotImplementedError
 
 
 class Primitive(metaclass=abc.ABCMeta):

--- a/pottery/counter.py
+++ b/pottery/counter.py
@@ -111,18 +111,7 @@ class RedisCounter(RedisDict, collections.Counter):
         return self.__class__.__name__ + '{' + repr_ + '}'
 
     def _make_counter(self) -> Counter[JSONTypes]:
-        counter: Counter[JSONTypes] = collections.Counter()
-        cursor = 0
-        while True:
-            cursor, encoded_dict = self._scan(cursor=cursor)
-            decoded_dict = {
-                self._decode(key): self._decode(value)
-                for key, value in encoded_dict.items()
-            }
-            counter.update(decoded_dict)
-            if cursor == 0:
-                break
-        return counter
+        return collections.Counter(self)
 
     __make_counter = _make_counter
 


### PR DESCRIPTION
These methods allow us to scan dicts and sets without having to use a
cursor. This in turn allows us to simplify our `Iterable_` abstract base
class and `.__iter__()` methods.