### PR TITLE
Properly compare RedisLists on different Redis dbs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # Pottery: Redis for Humans 🌎🌍🌏
 
 [Redis](http://redis.io/) is awesome, but [Redis
-commands](http://redis.io/commands) are not always fun.  Pottery is a Pythonic
-way to access Redis.  If you know how to use Python dicts, then you already
-know how to use Pottery.  Pottery is useful for accessing Redis more easily,
-and also for implementing microservice resilience patterns; and it has been
-battle tested in production at scale.
+commands](http://redis.io/commands) are not always intuitive.  Pottery is a
+Pythonic way to access Redis.  If you know how to use Python dicts, then you
+already know how to use Pottery.  Pottery is useful for accessing Redis more
+easily, and also for implementing microservice resilience patterns; and it has
+been battle tested in production at scale.
 
 [![Build status](https://img.shields.io/github/workflow/status/brainix/pottery/Python%20package/master)](https://github.com/brainix/pottery/actions?query=branch%3Amaster)
 [![Latest released version](https://badge.fury.io/py/pottery.svg)](https://badge.fury.io/py/pottery)

--- a/pottery/__init__.py
+++ b/pottery/__init__.py
@@ -16,11 +16,11 @@
 # --------------------------------------------------------------------------- #
 '''Redis for Humans.
 
-Redis is awesome, but Redis commands are not always fun.  Pottery is a Pythonic
-way to access Redis.  If you know how to use Python dicts, then you already
-know how to use Pottery.  Pottery is useful for accessing Redis more easily,
-and also for implementing microservice resilience patterns; and it has been
-battle tested in production at scale.
+Redis is awesome, but Redis commands are not always intuitive.  Pottery is a
+Pythonic way to access Redis.  If you know how to use Python dicts, then you
+already know how to use Pottery.  Pottery is useful for accessing Redis more
+easily, and also for implementing microservice resilience patterns; and it has
+been battle tested in production at scale.
 '''
 
 

--- a/pottery/__init__.py
+++ b/pottery/__init__.py
@@ -32,7 +32,7 @@ from typing_extensions import Final
 
 
 __title__: Final[str] = 'pottery'
-__version__: Final[str] = '2.3.1'
+__version__: Final[str] = '2.3.2'
 __description__: Final[str] = __doc__.split(sep='\n\n', maxsplit=1)[0]
 __url__: Final[str] = 'https://github.com/brainix/pottery'
 __author__: Final[str] = 'Rajiv Bakulesh Shah'

--- a/pottery/cache.py
+++ b/pottery/cache.py
@@ -123,7 +123,7 @@ def redis_cache(*,  # NoQA: C901
     on each call.
     '''
 
-    if redis is None:
+    if redis is None:  # pragma: no cover
         redis = _default_redis
 
     def decorator(func: F) -> F:

--- a/pottery/cache.py
+++ b/pottery/cache.py
@@ -123,7 +123,8 @@ def redis_cache(*,  # NoQA: C901
     on each call.
     '''
 
-    redis = _default_redis if redis is None else redis
+    if redis is None:
+        redis = _default_redis
 
     def decorator(func: F) -> F:
         nonlocal redis, key
@@ -308,7 +309,7 @@ class CachedOrderedDict(collections.OrderedDict):
                     self._cache._encode(default),
                 )
 
-    def __retry(self, callable: Callable[[], Any], try_num: int = 0) -> Any:
+    def __retry(self, callable: Callable[[], Any], *, try_num: int = 0) -> Any:
         try:
             return callable()
         except WatchError:  # pragma: no cover
@@ -331,7 +332,8 @@ class CachedOrderedDict(collections.OrderedDict):
         to_cache = {}
         with contextlib.suppress(AttributeError):
             arg = cast(InitMap, arg).items()
-        for dict_key, value in itertools.chain(cast(InitIter, arg), kwargs.items()):
+        items = itertools.chain(cast(InitIter, arg), kwargs.items())
+        for dict_key, value in items:
             if value is not self._SENTINEL:
                 to_cache[dict_key] = value
                 self._misses.discard(dict_key)

--- a/pottery/counter.py
+++ b/pottery/counter.py
@@ -70,7 +70,7 @@ class RedisCounter(RedisDict, collections.Counter):
         for key, value in kwargs.items():
             if dict_.get(key, 0) == 0:
                 original = self[key]
-            else:
+            else:  # pragma: no cover
                 original = dict_[key]
             dict_[key] = original + sign * value
 

--- a/pottery/dict.py
+++ b/pottery/dict.py
@@ -83,7 +83,7 @@ class RedisDict(Base, Iterable_, collections.abc.MutableMapping):
     #   https://stackoverflow.com/a/38534939
     __populate = _populate
 
-    def _encode_dict(self, dict_):
+    def _encode_dict(self, dict_: Mapping[JSONTypes, JSONTypes]) -> Dict[str, str]:
         encoded_dict = {
             self._encode(key): self._encode(value)
             for key, value in dict_.items()
@@ -100,8 +100,8 @@ class RedisDict(Base, Iterable_, collections.abc.MutableMapping):
         encoded_value = self.redis.hget(self.key, encoded_key)
         if encoded_value is None:
             raise KeyError(key)
-        decoded_value = self._decode(encoded_value)
-        return decoded_value
+        value = self._decode(encoded_value)
+        return value
 
     def __setitem__(self, key: JSONTypes, value: JSONTypes) -> None:
         'd.__setitem__(key, value) <==> d[key] = value.  O(1)'


### PR DESCRIPTION
Before this PR, `list1 == list2` would fail if both were `RedisList`s
but on different Redis databases. This is because we'd try to reuse the
same Redis pipeline for both lists.