### PR TITLE
Don't allow a RedisDeque to equal a RedisList...

### DIFF
--- a/pottery/__init__.py
+++ b/pottery/__init__.py
@@ -32,7 +32,7 @@ from typing_extensions import Final
 
 
 __title__: Final[str] = 'pottery'
-__version__: Final[str] = '2.3.4'
+__version__: Final[str] = '2.3.5'
 __description__: Final[str] = __doc__.split(sep='\n\n', maxsplit=1)[0]
 __url__: Final[str] = 'https://github.com/brainix/pottery'
 __author__: Final[str] = 'Rajiv Bakulesh Shah'

--- a/pottery/list.py
+++ b/pottery/list.py
@@ -261,10 +261,10 @@ class RedisList(Base, collections.abc.MutableSequence):
         self.redis.sort(self.key, desc=reverse, store=self.key)
 
     def __eq__(self, other: Any) -> bool:
-        if self is other:
-            return True
         if type(other) not in {self.__class__, self._ALLOWED_TO_EQUAL}:
             return False
+        if self is other:
+            return True
         if self._same_redis(other) and self.key == other.key:
             return True
 

--- a/pottery/list.py
+++ b/pottery/list.py
@@ -39,6 +39,9 @@ from typing import cast
 from redis import Redis
 from redis import ResponseError
 from redis.client import Pipeline
+# TODO: When we drop support for Python 3.7, change the following import to:
+#   from typing import final
+from typing_extensions import final
 
 from .annotations import F
 from .base import Base
@@ -277,9 +280,9 @@ class RedisList(Base, collections.abc.MutableSequence):
                 InefficientAccessWarning,
             )
             self_as_list = self.__to_list()
-            try:
-                other_as_list = cast('RedisList', other).to_list()
-            except AttributeError:
+            if isinstance(other, RedisList):
+                other_as_list = other.to_list()
+            else:
                 other_as_list = list(other)
             return self_as_list == other_as_list
 
@@ -352,6 +355,7 @@ class RedisList(Base, collections.abc.MutableSequence):
         class_name = self.__class__.__name__
         raise ValueError(f'{class_name}.remove(x): x not in {class_name}')
 
+    @final
     def to_list(self) -> List[JSONTypes]:
         'Convert the RedisList to a Python list.  O(n)'
         warnings.warn(

--- a/pottery/list.py
+++ b/pottery/list.py
@@ -263,11 +263,11 @@ class RedisList(Base, collections.abc.MutableSequence):
     def __eq__(self, other: Any) -> bool:
         if self is other:
             return True
+        if type(other) not in {self.__class__, self._ALLOWED_TO_EQUAL}:
+            return False
         if self._same_redis(other) and self.key == other.key:
             return True
 
-        if type(other) not in {self.__class__, self._ALLOWED_TO_EQUAL}:
-            return False
         with self._watch(other):
             if len(self) != len(other):
                 return False

--- a/pottery/list.py
+++ b/pottery/list.py
@@ -280,7 +280,7 @@ class RedisList(Base, collections.abc.MutableSequence):
                 InefficientAccessWarning,
             )
             self_as_list = self.__to_list()
-            if isinstance(other, RedisList):
+            if isinstance(other, self.__class__):
                 other_as_list = other.to_list()
             else:
                 other_as_list = list(other)

--- a/pottery/nextid.py
+++ b/pottery/nextid.py
@@ -24,6 +24,13 @@ Lua scripting:
 '''
 
 
+# TODO: Remove the following import after deferred evaluation of annotations
+# because the default.
+#   1. https://docs.python.org/3/whatsnew/3.7.html#whatsnew37-pep563
+#   2. https://www.python.org/dev/peps/pep-0563/
+#   3. https://www.python.org/dev/peps/pep-0649/
+from __future__ import annotations
+
 import concurrent.futures
 import contextlib
 from typing import ClassVar
@@ -147,7 +154,7 @@ class NextId(_Scripts, Primitive):
         )
         self.num_tries = num_tries
 
-    def __iter__(self) -> 'NextId':
+    def __iter__(self) -> NextId:
         return self
 
     def __next__(self) -> int:

--- a/pottery/redlock.py
+++ b/pottery/redlock.py
@@ -32,6 +32,13 @@ Lua scripting:
 '''
 
 
+# TODO: Remove the following import after deferred evaluation of annotations
+# because the default.
+#   1. https://docs.python.org/3/whatsnew/3.7.html#whatsnew37-pep563
+#   2. https://www.python.org/dev/peps/pep-0563/
+#   3. https://www.python.org/dev/peps/pep-0649/
+from __future__ import annotations
+
 import concurrent.futures
 import contextlib
 import functools
@@ -584,7 +591,7 @@ class Redlock(_Scripts, Primitive):
 
     __release = release
 
-    def __enter__(self) -> 'Redlock':
+    def __enter__(self) -> Redlock:
         '''You can use a Redlock as a context manager.
 
         Usage:

--- a/pottery/timer.py
+++ b/pottery/timer.py
@@ -17,6 +17,13 @@
 'Measure the execution time of small code snippets.'
 
 
+# TODO: Remove the following import after deferred evaluation of annotations
+# because the default.
+#   1. https://docs.python.org/3/whatsnew/3.7.html#whatsnew37-pep563
+#   2. https://www.python.org/dev/peps/pep-0563/
+#   3. https://www.python.org/dev/peps/pep-0649/
+from __future__ import annotations
+
 import timeit
 from types import TracebackType
 from typing import Optional
@@ -63,7 +70,7 @@ class ContextTimer:
         self._started = 0.0
         self._stopped = 0.0
 
-    def __enter__(self) -> 'ContextTimer':
+    def __enter__(self) -> ContextTimer:
         self.__start()
         return self
 

--- a/tests/test_deque.py
+++ b/tests/test_deque.py
@@ -200,7 +200,7 @@ class DequeTests(TestCase):
         d = RedisDeque('ghi', redis=self.redis, maxlen=2)
         assert repr(d) == "RedisDeque(['h', 'i'], maxlen=2)"
 
-    def test_eq_redislist_same_items(self):
+    def test_eq_redislist_same_redis_key(self):
         deque = RedisDeque('ghi', redis=self.redis)
         list_ = RedisList(redis=self.redis, key=deque.key)
         assert not deque == list_

--- a/tests/test_deque.py
+++ b/tests/test_deque.py
@@ -21,6 +21,7 @@ import itertools
 import unittest.mock
 
 from pottery import RedisDeque
+from pottery import RedisList
 from pottery.base import Base
 from tests.base import TestCase
 
@@ -198,3 +199,9 @@ class DequeTests(TestCase):
 
         d = RedisDeque('ghi', redis=self.redis, maxlen=2)
         assert repr(d) == "RedisDeque(['h', 'i'], maxlen=2)"
+
+    def test_eq_redislist_same_items(self):
+        deque = RedisDeque('ghi', redis=self.redis)
+        list_ = RedisList(redis=self.redis, key=deque.key)
+        assert not deque == list_
+        assert deque != list_

--- a/tests/test_list.py
+++ b/tests/test_list.py
@@ -168,7 +168,7 @@ class ListTests(TestCase):
         with self.assertRaises(NotImplementedError):
             squares.sort(key=str)
 
-    def test_eq_redisdeque_same_items(self):
+    def test_eq_redisdeque_same_redis_key(self):
         list_ = RedisList([1, 4, 9, 16, 25], redis=self.redis, key=self._KEY)
         deque = RedisDeque(redis=self.redis, key=self._KEY)
         assert not list_ == deque

--- a/tests/test_list.py
+++ b/tests/test_list.py
@@ -19,6 +19,7 @@
 import json
 
 from pottery import KeyExistsError
+from pottery import RedisDeque
 from pottery import RedisList
 from tests.base import TestCase
 
@@ -166,6 +167,12 @@ class ListTests(TestCase):
 
         with self.assertRaises(NotImplementedError):
             squares.sort(key=str)
+
+    def test_eq_redisdeque_same_items(self):
+        list_ = RedisList([1, 4, 9, 16, 25], redis=self.redis, key=self._KEY)
+        deque = RedisDeque(redis=self.redis, key=self._KEY)
+        assert not list_ == deque
+        assert list_ != deque
 
     def test_eq_same_object(self):
         squares = RedisList([1, 4, 9, 16, 25], redis=self.redis, key=self._KEY)


### PR DESCRIPTION
...even if they're both on the same Redis instance and have the same
key.

Before this PR:

```python
>>> from pottery import RedisDeque, RedisList
>>> RedisDeque(key='videos:dicts') == RedisList(key='videos:dicts')
True
```

As of this PR:

```python
>>> from pottery import RedisDeque, RedisList
>>> RedisDeque(key='videos:dicts') == RedisList(key='videos:dicts')
False
```