### PR TITLE
Prefer Redis UNLINK over DEL

### DIFF
--- a/pottery/base.py
+++ b/pottery/base.py
@@ -106,7 +106,7 @@ class _Common:
 
     def __del__(self) -> None:
         if self.key.startswith(self._RANDOM_KEY_PREFIX):
-            self.redis.delete(self.key)
+            self.redis.unlink(self.key)
             logger.warning(
                 "Deleted tmp <%s key='%s'> (instance is about to be destroyed)",
                 self.__class__.__name__,
@@ -179,7 +179,7 @@ class _Clearable(metaclass=abc.ABCMeta):
 
     def clear(self) -> None:
         'Remove the elements in a Redis-backed container.  O(n)'
-        self.redis.delete(self.key)
+        self.redis.unlink(self.key)
 
 
 class _Pipelined(metaclass=abc.ABCMeta):

--- a/pottery/cache.py
+++ b/pottery/cache.py
@@ -172,7 +172,7 @@ def redis_cache(*,  # NoQA: C901
 
         def cache_clear() -> None:
             nonlocal hits, misses
-            cast(Redis, redis).delete(cast(str, key))
+            cast(Redis, redis).unlink(cast(str, key))
             hits, misses = 0, 0
 
         wrapper.__wrapped__ = func  # type: ignore

--- a/pottery/hyper.py
+++ b/pottery/hyper.py
@@ -201,9 +201,9 @@ class HyperLogLog(Base):
             for encoded_value in encoded_values:
                 pipeline.copy(self.key, tmp_hll_key)  # type: ignore
                 pipeline.pfadd(tmp_hll_key, encoded_value)
-                pipeline.delete(tmp_hll_key)
+                pipeline.unlink(tmp_hll_key)
             # Pluck out the results of the pipeline.pfadd() commands.  Ignore
-            # the results of the enclosing pipeline.copy() and pipeline.delete()
+            # the results of the enclosing pipeline.copy() and pipeline.unlink()
             # commands.
             cardinalities_changed = pipeline.execute()[1::3]
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -23,7 +23,7 @@ Pygments==2.10.0
 pyparsing==3.0.6
 readme-renderer==30.0
 redis==4.1.0
-requests==2.26.0
+requests==2.27.1
 requests-toolbelt==0.9.1
 rfc3986==1.5.0
 six==1.16.0
@@ -31,7 +31,7 @@ toml==0.10.2
 tomli==2.0.0
 tqdm==4.62.3
 twine==3.7.1
-types-redis==4.1.2
+types-redis==4.1.3
 typing_extensions==4.0.1
 urllib3==1.26.7
 webencodings==0.5.1

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -76,17 +76,17 @@ class CommonTests(_BaseTestCase):
         assert not self.redis.exists(key)
 
     def test_del(self):
-        with unittest.mock.patch.object(self.redis, 'delete') as delete:
+        with unittest.mock.patch.object(self.redis, 'unlink') as unlink:
             del self.raj
-            delete.assert_called_with('pottery:raj')
-            delete.reset_mock()
+            unlink.assert_called_with('pottery:raj')
+            unlink.reset_mock()
 
             del self.nilika
-            delete.assert_called_with('pottery:nilika')
-            delete.reset_mock()
+            unlink.assert_called_with('pottery:nilika')
+            unlink.reset_mock()
 
             del self.luvh
-            delete.assert_not_called()
+            unlink.assert_not_called()
 
     def test_eq(self):
         assert self.raj == self.raj

--- a/tests/test_nextid.py
+++ b/tests/test_nextid.py
@@ -33,7 +33,7 @@ class NextIdTests(TestCase):
 
     def setUp(self):
         super().setUp()
-        self.redis.delete('nextid:current')
+        self.redis.unlink('nextid:current')
         self.ids = NextId(masters={self.redis})
         for master in self.ids.masters:
             master.set(self.ids.key, 0)


### PR DESCRIPTION
`UNLINK` is faster/non-blocking as it simply unlinks the key from the
keyspace. The actual memory reclaiming happens in a different thread.

https://redis.io/commands/unlink