### PR TITLE
Don't specify 'utf-8' argument to bytes.decode()

### DIFF
--- a/pottery/base.py
+++ b/pottery/base.py
@@ -157,7 +157,7 @@ class _Encodable:
     @staticmethod
     def _decode(encoded_value: AnyStr) -> JSONTypes:
         if isinstance(encoded_value, bytes):
-            string = encoded_value.decode('utf-8')
+            string = encoded_value.decode()
         else:
             string = encoded_value
         decoded_value: JSONTypes = json.loads(string)

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -152,7 +152,7 @@ class EncodableTests(TestCase):
         #   File "/Users/rajiv.shah/Documents/Code/pottery/pottery/dict.py", line 116, in <dictcomp>
         #     dict_ = {self._decode(key): self._decode(value) for key, value in items}
         #   File "/Users/rajiv.shah/Documents/Code/pottery/pottery/base.py", line 154, in _decode
-        #     decoded: JSONTypes = json.loads(value.decode('utf-8'))
+        #     decoded: JSONTypes = json.loads(value.decode())
         # AttributeError: 'str' object has no attribute 'decode'
         repr(tel)
 


### PR DESCRIPTION
`bytes.decode()` defaults to the `utf-8` encoding.