### PR TITLE
Properly configure logging for the Pottery library

### DIFF
--- a/pottery/__init__.py
+++ b/pottery/__init__.py
@@ -32,7 +32,7 @@ from typing_extensions import Final
 
 
 __title__: Final[str] = 'pottery'
-__version__: Final[str] = '2.3.5'
+__version__: Final[str] = '2.3.6'
 __description__: Final[str] = __doc__.split(sep='\n\n', maxsplit=1)[0]
 __url__: Final[str] = 'https://github.com/brainix/pottery'
 __author__: Final[str] = 'Rajiv Bakulesh Shah'

--- a/pottery/base.py
+++ b/pottery/base.py
@@ -55,6 +55,8 @@ from .exceptions import RandomKeyError
 
 
 logger: Final[logging.Logger] = logging.getLogger('pottery')
+logger.addHandler(logging.NullHandler())
+
 _default_url: Final[str] = os.environ.get('REDIS_URL', 'redis://localhost:6379/0')
 _default_redis: Final[Redis] = Redis.from_url(_default_url, socket_timeout=1)
 

--- a/pottery/monkey.py
+++ b/pottery/monkey.py
@@ -29,6 +29,7 @@ from typing_extensions import Final
 
 
 _logger: Final[logging.Logger] = logging.getLogger('pottery')
+_logger.addHandler(logging.NullHandler())
 
 
 # Monkey patch the JSON encoder to be able to JSONify any instance of any class


### PR DESCRIPTION
References:
1. https://docs.python.org/3/howto/logging.html#configuring-logging-for-a-library
2. https://github.com/elastic/elasticsearch-py/blob/013433e5008277144065ad8e82f66870b203269a/elasticsearch/__init__.py#L43