### PR TITLE
Implement RedisSet.__contains__() using SISMEMBER

### DIFF
--- a/pottery/set.py
+++ b/pottery/set.py
@@ -72,7 +72,11 @@ class RedisSet(Base, Iterable_, collections.abc.MutableSet):
 
     def __contains__(self, value: Any) -> bool:
         's.__contains__(element) <==> element in s.  O(1)'
-        return next(self.contains_many(value))
+        try:
+            encoded_value = self._encode(value)
+        except TypeError:
+            return False
+        return self.redis.sismember(self.key, encoded_value)  # Available since Redis 1.0.0
 
     def contains_many(self, *values: JSONTypes) -> Generator[bool, None, None]:
         'Yield whether this RedisSet contains multiple elements.  O(n)'

--- a/tests/test_set.py
+++ b/tests/test_set.py
@@ -50,8 +50,8 @@ class SetTests(TestCase):
 
     def test_contains_many_metasyntactic_variables(self):
         metasyntactic_variables = RedisSet({'foo', 'bar', 'zap', 'a'}, redis=self.redis)
-        contains_many = metasyntactic_variables.contains_many('foo', 'bar', 'baz', 'quz')
-        assert tuple(contains_many) == (True, True, False, False)
+        contains_many = metasyntactic_variables.contains_many('foo', 'bar', object(), 'baz', 'quz')
+        assert tuple(contains_many) == (True, True, False, False, False)
 
     def test_contains_many_uuids(self):
         NUM_ELEMENTS = 5000


### PR DESCRIPTION
[`SISMEMBER`](https://redis.io/commands/sismember) has been available since Redis 1.0.0, whereas [`SMISMEMBER`](https://redis.io/commands/smismember) has been available since only Redis 6.2.0.