### PR TITLE
Rename Base class to Container

### DIFF
--- a/pottery/base.py
+++ b/pottery/base.py
@@ -289,7 +289,7 @@ class _Comparable(abc.ABC):
         return equals
 
 
-class Base(_Common, _Encodable, _Clearable, _Pipelined, _Comparable):
+class Container(_Common, _Encodable, _Clearable, _Pipelined, _Comparable):
     'Base class for Redis-backed collections.'
 
 

--- a/pottery/bloom.py
+++ b/pottery/bloom.py
@@ -34,7 +34,7 @@ import mmh3
 from typing_extensions import final
 
 from .annotations import F
-from .base import Base
+from .base import Container
 from .base import JSONTypes
 
 
@@ -201,7 +201,7 @@ class BloomFilterABC(abc.ABC):
         return next(self.contains_many(value))
 
 
-class BloomFilter(BloomFilterABC, Base):
+class BloomFilter(BloomFilterABC, Container):
     '''Redis-backed Bloom filter with an API similar to Python sets.
 
     Bloom filters are a powerful data structure that help you to answer the

--- a/pottery/dict.py
+++ b/pottery/dict.py
@@ -35,7 +35,7 @@ from typing import cast
 from redis import Redis
 from redis.client import Pipeline
 
-from .base import Base
+from .base import Container
 from .base import Iterable_
 from .base import JSONTypes
 from .exceptions import InefficientAccessWarning
@@ -48,7 +48,7 @@ InitIter = Iterable[InitItem]
 InitArg = Union[InitMap, InitIter]
 
 
-class RedisDict(Base, Iterable_, collections.abc.MutableMapping):
+class RedisDict(Container, Iterable_, collections.abc.MutableMapping):
     'Redis-backed container compatible with Python dicts.'
 
     def __init__(self,

--- a/pottery/hyper.py
+++ b/pottery/hyper.py
@@ -32,12 +32,12 @@ from typing import cast
 from redis import Redis
 
 from .annotations import RedisValues
-from .base import Base
+from .base import Container
 from .base import JSONTypes
 from .base import random_key
 
 
-class HyperLogLog(Base):
+class HyperLogLog(Container):
     '''Redis-backed HyperLogLog with a Pythonic API.
 
     HyperLogLogs are an interesting data structure designed to answer the

--- a/pottery/list.py
+++ b/pottery/list.py
@@ -42,7 +42,7 @@ from redis.client import Pipeline
 from typing_extensions import final
 
 from .annotations import F
-from .base import Base
+from .base import Container
 from .base import JSONTypes
 from .exceptions import InefficientAccessWarning
 from .exceptions import KeyExistsError
@@ -58,7 +58,7 @@ def _raise_on_error(func: F) -> Callable[[F], F]:
     return wrapper
 
 
-class RedisList(Base, collections.abc.MutableSequence):
+class RedisList(Container, collections.abc.MutableSequence):
     'Redis-backed container compatible with Python lists.'
 
     _ALLOWED_TO_EQUAL: type = list

--- a/pottery/queue.py
+++ b/pottery/queue.py
@@ -29,13 +29,13 @@ from typing import cast
 
 from redis import WatchError
 
-from .base import Base
+from .base import Container
 from .base import JSONTypes
 from .exceptions import QueueEmptyError
 from .timer import ContextTimer
 
 
-class RedisSimpleQueue(Base):
+class RedisSimpleQueue(Container):
     RETRY_DELAY: ClassVar[int] = 200
 
     def qsize(self) -> int:

--- a/pottery/set.py
+++ b/pottery/set.py
@@ -35,14 +35,14 @@ from redis import Redis
 from redis.client import Pipeline
 from typing_extensions import Literal
 
-from .base import Base
+from .base import Container
 from .base import Iterable_
 from .base import JSONTypes
 from .exceptions import InefficientAccessWarning
 from .exceptions import KeyExistsError
 
 
-class RedisSet(Base, Iterable_, collections.abc.MutableSet):
+class RedisSet(Container, Iterable_, collections.abc.MutableSet):
     'Redis-backed container compatible with Python sets.'
 
     def __init__(self,

--- a/tests/test_deque.py
+++ b/tests/test_deque.py
@@ -22,7 +22,7 @@ import unittest.mock
 
 from pottery import RedisDeque
 from pottery import RedisList
-from pottery.base import Base
+from pottery.base import Container
 from tests.base import TestCase
 
 
@@ -63,7 +63,7 @@ class DequeTests(TestCase):
         assert d == collections.deque(['c', 'b', 'a'])
 
     def test_init_with_wrong_type_maxlen(self):
-        with unittest.mock.patch.object(Base, '__del__') as delete, \
+        with unittest.mock.patch.object(Container, '__del__') as delete, \
              self.assertRaises(TypeError):
             delete.return_value = None
             RedisDeque(redis=self.redis, maxlen='2')


### PR DESCRIPTION
`Container` is more descriptive as to what the base class *is.*