### PR TITLE
Dramatically speed up CachedOrderedDict.__init__()

### DIFF
--- a/pottery/__init__.py
+++ b/pottery/__init__.py
@@ -32,7 +32,7 @@ from typing_extensions import Final
 
 
 __title__: Final[str] = 'pottery'
-__version__: Final[str] = '2.3.6'
+__version__: Final[str] = '2.3.7'
 __description__: Final[str] = __doc__.split(sep='\n\n', maxsplit=1)[0]
 __url__: Final[str] = 'https://github.com/brainix/pottery'
 __author__: Final[str] = 'Rajiv Bakulesh Shah'

--- a/pottery/bloom.py
+++ b/pottery/bloom.py
@@ -34,8 +34,8 @@ import mmh3
 from typing_extensions import final
 
 from .annotations import F
+from .annotations import JSONTypes
 from .base import Container
-from .base import JSONTypes
 
 
 # TODO: When we drop support for Python 3.7, stop using @_store_on_self().  Use

--- a/pottery/cache.py
+++ b/pottery/cache.py
@@ -260,7 +260,7 @@ class CachedOrderedDict(collections.OrderedDict):
                 item = (dict_key, value)
                 items.append(item)
         super().__init__()
-        self.update(items)
+        self.__update(items)
 
     def misses(self) -> Collection[JSONTypes]:
         return frozenset(self._misses)
@@ -348,3 +348,5 @@ class CachedOrderedDict(collections.OrderedDict):
                 self._misses.discard(cast(JSONTypes, dict_key))
             super().__setitem__(dict_key, value)
         self._cache.update(to_cache)
+
+    __update = update

--- a/pottery/cache.py
+++ b/pottery/cache.py
@@ -29,8 +29,11 @@ from typing import ClassVar
 from typing import Collection
 from typing import Hashable
 from typing import Iterable
+from typing import Mapping
 from typing import NamedTuple
+from typing import Tuple
 from typing import TypeVar
+from typing import Union
 from typing import cast
 
 from redis import Redis
@@ -39,14 +42,19 @@ from redis.exceptions import WatchError
 #   from typing import Final
 from typing_extensions import Final
 
-from .base import JSONTypes
+from .annotations import JSONTypes
 from .base import _default_redis
 from .base import logger
 from .base import random_key
-from .dict import InitArg
-from .dict import InitIter
 from .dict import RedisDict
 
+
+F = TypeVar('F', bound=Callable[..., JSONTypes])
+
+UpdateMap = Mapping[JSONTypes, JSONTypes | object]
+UpdateItem = Tuple[JSONTypes, JSONTypes | object]
+UpdateIter = Iterable[UpdateItem]
+UpdateArg = Union[UpdateMap, UpdateIter]
 
 _DEFAULT_TIMEOUT: Final[int] = 60   # seconds
 
@@ -66,9 +74,6 @@ class CacheInfo(NamedTuple):
 def _arg_hash(*args: Hashable, **kwargs: Hashable) -> int:
     kwargs_items = frozenset(kwargs.items())
     return hash((args, kwargs_items))
-
-
-F = TypeVar('F', bound=Callable[..., JSONTypes])
 
 
 def redis_cache(*,  # NoQA: C901
@@ -248,13 +253,14 @@ class CachedOrderedDict(collections.OrderedDict):
             )
             for dict_key, encoded_value in zip(dict_keys, encoded_values):
                 if encoded_value is None:
-                    value = self._SENTINEL
                     self._misses.add(dict_key)
+                    value = self._SENTINEL
                 else:
                     value = self._cache._decode(encoded_value)
                 item = (dict_key, value)
                 items.append(item)
-        return super().__init__(items)
+        super().__init__()
+        self.update(items)
 
     def misses(self) -> Collection[JSONTypes]:
         return frozenset(self._misses)
@@ -265,7 +271,7 @@ class CachedOrderedDict(collections.OrderedDict):
                     value: JSONTypes | object,
                     ) -> None:
         'Set self[dict_key] to value.'
-        if value is not self._SENTINEL:
+        if value is not self._SENTINEL:  # pragma: no cover
             self._cache[dict_key] = value
             self._misses.discard(dict_key)
         return super().__setitem__(dict_key, value)
@@ -318,24 +324,27 @@ class CachedOrderedDict(collections.OrderedDict):
             raise
 
     @_set_expiration
-    def update(self, arg: InitArg = tuple(), **kwargs: JSONTypes) -> None:  # type: ignore
+    def update(self,  # type: ignore
+               arg: UpdateArg = tuple(),
+               **kwargs: JSONTypes | object,
+               ) -> None:
         '''D.update([E, ]**F) -> None.  Update D from dict/iterable E and F.
         If E is present and has an .items() method, then does:  for k in E: D[k] = E[k]
         If E is present and lacks an .items() method, then does:  for k, v in E: D[k] = v
         In either case, this is followed by: for k in F:  D[k] = F[k]
 
         The base class, OrderedDict, has an .update() method that works just
-        fine.  The trouble is that it executes multiple calls to .__setitem__()
-        therefore multiple round trips to Redis.  This overridden .update()
-        makes a single bulk call to Redis.
+        fine.  The trouble is that it executes multiple calls to
+        self.__setitem__() therefore multiple round trips to Redis.  This
+        overridden .update() makes a single bulk call to Redis.
         '''
         to_cache = {}
         if isinstance(arg, collections.abc.Mapping):
             arg = arg.items()
-        items = itertools.chain(cast(InitIter, arg), kwargs.items())
+        items = itertools.chain(arg, kwargs.items())
         for dict_key, value in items:
             if value is not self._SENTINEL:
                 to_cache[dict_key] = value
-                self._misses.discard(dict_key)
+                self._misses.discard(cast(JSONTypes, dict_key))
             super().__setitem__(dict_key, value)
         self._cache.update(to_cache)

--- a/pottery/cache.py
+++ b/pottery/cache.py
@@ -51,8 +51,8 @@ from .dict import RedisDict
 
 F = TypeVar('F', bound=Callable[..., JSONTypes])
 
-UpdateMap = Mapping[JSONTypes, JSONTypes | object]
-UpdateItem = Tuple[JSONTypes, JSONTypes | object]
+UpdateMap = Mapping[JSONTypes, Union[JSONTypes, object]]
+UpdateItem = Tuple[JSONTypes, Union[JSONTypes, object]]
 UpdateIter = Iterable[UpdateItem]
 UpdateArg = Union[UpdateMap, UpdateIter]
 

--- a/pottery/counter.py
+++ b/pottery/counter.py
@@ -36,7 +36,7 @@ from typing import cast
 from redis.client import Pipeline
 from typing_extensions import Counter
 
-from .base import JSONTypes
+from .annotations import JSONTypes
 from .dict import RedisDict
 
 

--- a/pottery/deque.py
+++ b/pottery/deque.py
@@ -29,7 +29,7 @@ from typing import cast
 from redis import Redis
 from redis.client import Pipeline
 
-from .base import JSONTypes
+from .annotations import JSONTypes
 from .exceptions import InefficientAccessWarning
 from .list import RedisList
 

--- a/pottery/dict.py
+++ b/pottery/dict.py
@@ -35,9 +35,9 @@ from typing import cast
 from redis import Redis
 from redis.client import Pipeline
 
+from .annotations import JSONTypes
 from .base import Container
 from .base import Iterable_
-from .base import JSONTypes
 from .exceptions import InefficientAccessWarning
 from .exceptions import KeyExistsError
 

--- a/pottery/hyper.py
+++ b/pottery/hyper.py
@@ -31,9 +31,9 @@ from typing import cast
 
 from redis import Redis
 
+from .annotations import JSONTypes
 from .annotations import RedisValues
 from .base import Container
-from .base import JSONTypes
 from .base import random_key
 
 

--- a/pottery/list.py
+++ b/pottery/list.py
@@ -42,8 +42,8 @@ from redis.client import Pipeline
 from typing_extensions import final
 
 from .annotations import F
+from .annotations import JSONTypes
 from .base import Container
-from .base import JSONTypes
 from .exceptions import InefficientAccessWarning
 from .exceptions import KeyExistsError
 

--- a/pottery/queue.py
+++ b/pottery/queue.py
@@ -29,8 +29,8 @@ from typing import cast
 
 from redis import WatchError
 
+from .annotations import JSONTypes
 from .base import Container
-from .base import JSONTypes
 from .exceptions import QueueEmptyError
 from .timer import ContextTimer
 

--- a/pottery/set.py
+++ b/pottery/set.py
@@ -35,9 +35,9 @@ from redis import Redis
 from redis.client import Pipeline
 from typing_extensions import Literal
 
+from .annotations import JSONTypes
 from .base import Container
 from .base import Iterable_
-from .base import JSONTypes
 from .exceptions import InefficientAccessWarning
 from .exceptions import KeyExistsError
 


### PR DESCRIPTION
Previously, we were making multiple round trips to Redis, one per
`dict_key`. Now, we make a single bulk call to Redis.