### PR TITLE
In Redlock, consistently measure time in seconds

### DIFF
--- a/README.md
+++ b/README.md
@@ -443,10 +443,10 @@ False
 ```
 
 If 10 seconds isn&rsquo;t enough to complete executing your critical section,
-then you can specify your own auto release time (in milliseconds):
+then you can specify your own auto release time (in seconds):
 
 ```python
->>> printer_lock = Redlock(key='printer', masters={redis}, auto_release_time=15*1000)
+>>> printer_lock = Redlock(key='printer', masters={redis}, auto_release_time=15)
 >>> if printer_lock.acquire():
 ...     # Critical section - print stuff here.
 ...     time.sleep(10)
@@ -517,7 +517,7 @@ Here&rsquo;s how to use `synchronize()`:
 
 ```python
 >>> from pottery import synchronize
->>> @synchronize(key='synchronized-func', masters={redis}, auto_release_time=500, blocking=True, timeout=-1)
+>>> @synchronize(key='synchronized-func', masters={redis}, auto_release_time=.5, blocking=True, timeout=-1)
 ... def func():
 ...   # Only one thread can execute this function at a time.
 ...   return True

--- a/pottery/__init__.py
+++ b/pottery/__init__.py
@@ -32,7 +32,7 @@ from typing_extensions import Final
 
 
 __title__: Final[str] = 'pottery'
-__version__: Final[str] = '2.3.7'
+__version__: Final[str] = '3.0.0'
 __description__: Final[str] = __doc__.split(sep='\n\n', maxsplit=1)[0]
 __url__: Final[str] = 'https://github.com/brainix/pottery'
 __author__: Final[str] = 'Rajiv Bakulesh Shah'

--- a/pottery/base.py
+++ b/pottery/base.py
@@ -296,7 +296,7 @@ class Primitive(abc.ABC):
 
     @property
     @abc.abstractmethod
-    def KEY_PREFIX(self) -> str:
+    def _KEY_PREFIX(self) -> str:
         'Redis key prefix/namespace.'
 
     __slots__ = ('__key', 'masters', 'raise_on_redis_errors')
@@ -319,7 +319,7 @@ class Primitive(abc.ABC):
 
     @key.setter
     def key(self, value: str) -> None:
-        self.__key = f'{self.KEY_PREFIX}:{value}'
+        self.__key = f'{self._KEY_PREFIX}:{value}'
 
     def _check_enough_masters_up(self,
                                  raise_on_redis_errors: bool | None,

--- a/pottery/nextid.py
+++ b/pottery/nextid.py
@@ -137,15 +137,15 @@ class NextId(_Scripts):
 
     __slots__ = ('num_tries',)
 
-    KEY_PREFIX: ClassVar[str] = 'nextid'
-    NUM_TRIES: ClassVar[int] = 3
+    _KEY_PREFIX: ClassVar[str] = 'nextid'
+    _NUM_TRIES: ClassVar[int] = 3
 
     def __init__(self,
                  *,
                  key: str = 'current',
                  masters: Iterable[Redis] = frozenset(),
                  raise_on_redis_errors: bool = False,
-                 num_tries: int = NUM_TRIES,
+                 num_tries: int = _NUM_TRIES,
                  ) -> None:
         '''Initialize a NextId ID generator.
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 bandit==1.7.2
 bleach==4.1.0
 certifi==2021.10.8
-charset-normalizer==2.0.11
+charset-normalizer==2.0.12
 click==8.0.3
 colorama==0.4.4
 coverage==6.3.1
@@ -42,7 +42,7 @@ tomli==2.0.1
 tqdm==4.62.3
 twine==3.8.0
 types-redis==4.1.15
-typing_extensions==4.0.1
+typing_extensions==4.1.1
 urllib3==1.26.8
 webencodings==0.5.1
 wrapt==1.13.3


### PR DESCRIPTION
Prior to this PR:
1. `timeout` was in seconds
2. `.locked()` returned milliseconds
3. `auto_release_time` was in milliseconds
4. `RETRY_DELAY` was in milliseconds

As of this PR:
1. `timeout` is in seconds
2. `.locked()` returns seconds
3. `auto_release_time` is in seconds
4. `_RETRY_DELAY` is in seconds