### PR TITLE
Document AIORedlock usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -396,8 +396,8 @@ access to your resource:
 
 ```python
 >>> if printer_lock.acquire():
-...     print('printer_lock is locked')
 ...     # Critical section - print stuff here.
+...     print('printer_lock is locked')
 ...     printer_lock.release()
 printer_lock is locked
 >>> bool(printer_lock.locked())
@@ -409,8 +409,8 @@ Or you can protect access to your resource inside a context manager:
 
 ```python
 >>> with printer_lock:
-...     print('printer_lock is locked')
 ...     # Critical section - print stuff here.
+...     print('printer_lock is locked')
 printer_lock is locked
 >>> bool(printer_lock.locked())
 False
@@ -563,6 +563,7 @@ Or you can protect access to your resource inside a context manager:
 ...     aioredis = AIORedis.from_url('redis://localhost:6379/1')
 ...     shower = AIORedlock(key='shower', masters={aioredis})
 ...     async with shower:
+...         # Critical section - no other coroutine can enter while we hold the lock.
 ...         print(f"shower is {'occupied' if await shower.locked() else 'available'}")
 ...     print(f"shower is {'occupied' if await shower.locked() else 'available'}")
 ...

--- a/README.md
+++ b/README.md
@@ -540,13 +540,13 @@ Instantiate an `AIORedlock` and protect a resource:
 >>> import asyncio
 >>> from redis.asyncio import Redis as AIORedis
 >>> from pottery import AIORedlock
->>> aioredis = AIORedis.from_url('redis://localhost:6379/1')
 >>> async def main():
+...     aioredis = AIORedis.from_url('redis://localhost:6379/1')
 ...     shower = AIORedlock(key='shower', masters={aioredis})
-...     await shower.acquire()
-...     print(f"shower is {'occupied' if await shower.locked() else 'available'}")
-...     # Critical section - print stuff here.
-...     await shower.release()
+...     if await shower.acquire():
+...         # Critical section - no other coroutine can enter while we hold the lock.
+...         print(f"shower is {'occupied' if await shower.locked() else 'available'}")
+...         await shower.release()
 ...     print(f"shower is {'occupied' if await shower.locked() else 'available'}")
 ...
 >>> asyncio.run(main())
@@ -560,6 +560,7 @@ Or you can protect access to your resource inside a context manager:
 ```python
 >>> asyncio.set_event_loop(asyncio.new_event_loop())
 >>> async def main():
+...     aioredis = AIORedis.from_url('redis://localhost:6379/1')
 ...     shower = AIORedlock(key='shower', masters={aioredis})
 ...     async with shower:
 ...         print(f"shower is {'occupied' if await shower.locked() else 'available'}")

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ been battle tested in production at scale.
 - [Redlock 🔒](#redlock)
     - [synchronize() 👯‍♀️](#synchronize)
 - [AIORedlock 🔒](#aioredlock)
-- [NextId 🔢](#nextid)
+- [NextID 🔢](#nextid)
 - [redis_cache()](#redis_cache)
 - [CachedOrderedDict](#cachedordereddict)
 - [Bloom filters 🌸](#bloom-filters)
@@ -573,17 +573,17 @@ shower is available
 
 
 
-## <a name="nextid"></a>NextId 🔢
+## <a name="nextid"></a>NextID 🔢
 
-`NextId` safely and reliably produces increasing IDs across threads, processes,
+`NextID` safely and reliably produces increasing IDs across threads, processes,
 and even machines, without a single point of failure.  [Rationale and algorithm
 description.](http://antirez.com/news/102)
 
 Instantiate an ID generator:
 
 ```python
->>> from pottery import NextId
->>> tweet_ids = NextId(key='tweet-ids', masters={redis})
+>>> from pottery import NextID
+>>> tweet_ids = NextID(key='tweet-ids', masters={redis})
 >>>
 ```
 

--- a/pottery/aioredlock.py
+++ b/pottery/aioredlock.py
@@ -14,7 +14,22 @@
 #   See the License for the specific language governing permissions and       #
 #   limitations under the License.                                            #
 # --------------------------------------------------------------------------- #
-'Asynchronous distributed Redis-powered lock.'
+'''Asynchronous distributed Redis-powered lock.
+
+This algorithm safely and reliably provides a mutually-exclusive locking
+primitive to protect a resource shared across coroutines, threads, processes,
+and even machines, without a single point of failure.
+
+Rationale and algorithm description:
+    http://redis.io/topics/distlock
+
+Reference implementations:
+    https://github.com/antirez/redlock-rb
+    https://github.com/SPSCommerce/redlock-py
+
+Lua scripting:
+    https://github.com/andymccurdy/redis-py#lua-scripting
+'''
 
 
 # TODO: Remove the following import after deferred evaluation of annotations
@@ -50,6 +65,80 @@ from .timer import ContextTimer
 
 
 class AIORedlock(Scripts, AIOPrimitive):
+    '''Asynchronous distributed Redis-powered lock.
+
+    This algorithm safely and reliably provides a mutually-exclusive locking
+    primitive to protect a resource shared across coroutines, threads,
+    processes, and even machines, without a single point of failure.
+
+    Rationale and algorithm description:
+        http://redis.io/topics/distlock
+
+    Usage:
+
+        >>> import asyncio
+        >>> from redis.asyncio import Redis as AIORedis
+        >>> async def main():
+        ...     aioredis = AIORedis.from_url('redis://localhost:6379/1', socket_timeout=1)
+        ...     shower = AIORedlock(key='shower', masters={aioredis})
+        ...     await shower.acquire()
+        ...     print(f"shower is {'occupied' if await shower.locked() else 'available'}")
+        ...     # Critical section - no other coroutine can enter while we hold the lock.
+        ...     await shower.release()
+        ...     print(f"shower is {'occupied' if await shower.locked() else 'available'}")
+        ...
+        >>> asyncio.run(main())
+        shower is occupied
+        shower is available
+
+    AIORedlocks time out (by default, after 10 seconds).  You should take care
+    to ensure that your critical section completes well within the timeout.  The
+    reasons that AIORedlocks time out are to preserve "liveness"
+    (http://redis.io/topics/distlock#liveness-arguments) and to avoid deadlocks
+    (in the event that a process dies inside a critical section before it
+    releases its lock).
+
+        >>> async def main():
+        ...     aioredis = AIORedis.from_url('redis://localhost:6379/1', socket_timeout=1)
+        ...     shower = AIORedlock(key='shower', masters={aioredis})
+        ...     if await shower.acquire():
+        ...         # Critical section - no other coroutine can enter while we hold the lock.
+        ...         await asyncio.sleep(10)
+        ...     print(f"shower is {'occupied' if await shower.locked() else 'available'}")
+        >>> asyncio.run(main())
+        shower is available
+
+    If 10 seconds isn't enough to complete executing your critical section,
+    then you can specify your own timeout:
+
+        >>> async def main():
+        ...     aioredis = AIORedis.from_url('redis://localhost:6379/1', socket_timeout=1)
+        ...     shower = AIORedlock(key='shower', masters={aioredis}, auto_release_time=15)
+        ...     if await shower.acquire():
+        ...         # Critical section - no other coroutine can enter while we hold the lock.
+        ...         await asyncio.sleep(10)
+        ...     print(f"shower is {'occupied' if await shower.locked() else 'available'}")
+        ...     await asyncio.sleep(5)
+        ...     print(f"shower is {'occupied' if await shower.locked() else 'available'}")
+        ...
+        >>> asyncio.run(main())
+        shower is occupied
+        shower is available
+
+    You can use a AIORedlock as a context manager:
+
+        >>> async def main():
+        ...     aioredis = AIORedis.from_url('redis://localhost:6379/1', socket_timeout=1)
+        ...     shower = AIORedlock(key='shower', masters={aioredis}, auto_release_time=15)
+        ...     async with shower:
+        ...         print(f"shower is {'occupied' if await shower.locked() else 'available'}")
+        ...         # Critical section - no other coroutine can enter while we hold the lock.
+        ...     print(f"shower is {'occupied' if await shower.locked() else 'available'}")
+        >>> asyncio.run(main())
+        shower is occupied
+        shower is available
+    '''
+
     __slots__ = (
         'auto_release_time',
         'num_extensions',
@@ -317,3 +406,13 @@ class AIORedlock(Scripts, AIOPrimitive):
 
     def __repr__(self) -> str:
         return f'<{self.__class__.__name__} key={self.key}>'
+
+
+if __name__ == '__main__':
+    # Run the doctests in this module with:
+    #   $ source venv/bin/activate
+    #   $ python3 -m pottery.aioredlock
+    #   $ deactivate
+    with contextlib.suppress(ImportError):
+        from tests.base import run_doctests
+        run_doctests()

--- a/pottery/aioredlock.py
+++ b/pottery/aioredlock.py
@@ -81,10 +81,10 @@ class AIORedlock(Scripts, AIOPrimitive):
         >>> async def main():
         ...     aioredis = AIORedis.from_url('redis://localhost:6379/1', socket_timeout=1)
         ...     shower = AIORedlock(key='shower', masters={aioredis})
-        ...     await shower.acquire()
-        ...     print(f"shower is {'occupied' if await shower.locked() else 'available'}")
-        ...     # Critical section - no other coroutine can enter while we hold the lock.
-        ...     await shower.release()
+        ...     if await shower.acquire():
+        ...         # Critical section - no other coroutine can enter while we hold the lock.
+        ...         print(f"shower is {'occupied' if await shower.locked() else 'available'}")
+        ...         await shower.release()
         ...     print(f"shower is {'occupied' if await shower.locked() else 'available'}")
         ...
         >>> asyncio.run(main())


### PR DESCRIPTION
This isn't ready to merge. When I run the doctests in the README, I get
this error:

    File "README.md", line 568, in README.md
    Failed example:
        asyncio.run(main())
    Exception raised:
        Traceback (most recent call last):
          File "/Users/rajiv.shah/Documents/Code/pottery/venv/lib/python3.10/site-packages/redis/asyncio/connection.py", line 920, in read_response
            response = await self._parser.read_response(
          File "/Users/rajiv.shah/Documents/Code/pottery/venv/lib/python3.10/site-packages/redis/asyncio/connection.py", line 530, in read_response
            await self.read_from_socket()
          File "/Users/rajiv.shah/Documents/Code/pottery/venv/lib/python3.10/site-packages/redis/asyncio/connection.py", line 489, in read_from_socket
            buffer = await self._stream.read(self._read_size)
          File "/Users/rajiv.shah/.pyenv/versions/3.10.2/lib/python3.10/asyncio/streams.py", line 669, in read
            await self._wait_for_data('read')
          File "/Users/rajiv.shah/.pyenv/versions/3.10.2/lib/python3.10/asyncio/streams.py", line 502, in _wait_for_data
            await self._waiter
        RuntimeError: Task <Task pending name='Task-9' coro=<AIORedlock.__acquire_master() running at /Users/rajiv.shah/Documents/Code/pottery/pottery/aioredlock.py:79> cb=[as_completed.<locals>._on_completion() at /Users/rajiv.shah/.pyenv/versions/3.10.2/lib/python3.10/asyncio/tasks.py:558]> got Future <Future pending> attached to a different loop

        During handling of the above exception, another exception occurred:

        Traceback (most recent call last):
          File "/Users/rajiv.shah/.pyenv/versions/3.10.2/lib/python3.10/doctest.py", line 1346, in __run
            exec(compile(example.source, filename, "single",
          File "<doctest README.md[133]>", line 1, in <module>
            asyncio.run(main())
          File "/Users/rajiv.shah/.pyenv/versions/3.10.2/lib/python3.10/asyncio/runners.py", line 44, in run
            return loop.run_until_complete(main)
          File "/Users/rajiv.shah/.pyenv/versions/3.10.2/lib/python3.10/asyncio/base_events.py", line 641, in run_until_complete
            return future.result()
          File "<doctest README.md[132]>", line 3, in main
            async with shower:
          File "/Users/rajiv.shah/Documents/Code/pottery/pottery/aioredlock.py", line 226, in __aenter__
            await self.acquire()
          File "/Users/rajiv.shah/Documents/Code/pottery/pottery/aioredlock.py", line 127, in acquire
            num_masters_acquired += await coro
          File "/Users/rajiv.shah/.pyenv/versions/3.10.2/lib/python3.10/asyncio/tasks.py", line 571, in _wait_for_one
            return f.result()  # May raise f.exception().
          File "/Users/rajiv.shah/Documents/Code/pottery/pottery/aioredlock.py", line 79, in __acquire_master
            acquired = await master.set(
          File "/Users/rajiv.shah/Documents/Code/pottery/venv/lib/python3.10/site-packages/redis/asyncio/client.py", line 467, in execute_command
            return await conn.retry.call_with_retry(
          File "/Users/rajiv.shah/Documents/Code/pottery/venv/lib/python3.10/site-packages/redis/asyncio/retry.py", line 50, in call_with_retry
            return await do()
          File "/Users/rajiv.shah/Documents/Code/pottery/venv/lib/python3.10/site-packages/redis/asyncio/client.py", line 446, in _send_command_parse_response
            return await self.parse_response(conn, command_name, **options)
          File "/Users/rajiv.shah/Documents/Code/pottery/venv/lib/python3.10/site-packages/redis/asyncio/client.py", line 485, in parse_response
            response = await connection.read_response()
          File "/Users/rajiv.shah/Documents/Code/pottery/venv/lib/python3.10/site-packages/redis/asyncio/connection.py", line 932, in read_response
            await self.disconnect()
          File "/Users/rajiv.shah/Documents/Code/pottery/venv/lib/python3.10/site-packages/redis/asyncio/connection.py", line 824, in disconnect
            self._writer.close()  # type: ignore[union-attr]
          File "/Users/rajiv.shah/.pyenv/versions/3.10.2/lib/python3.10/asyncio/streams.py", line 338, in close
            return self._transport.close()
          File "/Users/rajiv.shah/.pyenv/versions/3.10.2/lib/python3.10/asyncio/selector_events.py", line 700, in close
            self._loop.call_soon(self._call_connection_lost, None)
          File "/Users/rajiv.shah/.pyenv/versions/3.10.2/lib/python3.10/asyncio/base_events.py", line 745, in call_soon
            self._check_closed()
          File "/Users/rajiv.shah/.pyenv/versions/3.10.2/lib/python3.10/asyncio/base_events.py", line 510, in _check_closed
            raise RuntimeError('Event loop is closed')
        RuntimeError: Event loop is closed
