### PR TITLE
Clean up asyncio unit tests and doctests

### DIFF
--- a/pottery/aioredlock.py
+++ b/pottery/aioredlock.py
@@ -79,7 +79,7 @@ class AIORedlock(Scripts, AIOPrimitive):
         >>> import asyncio
         >>> from redis.asyncio import Redis as AIORedis
         >>> async def main():
-        ...     aioredis = AIORedis.from_url('redis://localhost:6379/1', socket_timeout=1)
+        ...     aioredis = AIORedis.from_url('redis://localhost:6379/1')
         ...     shower = AIORedlock(key='shower', masters={aioredis})
         ...     if await shower.acquire():
         ...         # Critical section - no other coroutine can enter while we hold the lock.
@@ -99,7 +99,7 @@ class AIORedlock(Scripts, AIOPrimitive):
     releases its lock).
 
         >>> async def main():
-        ...     aioredis = AIORedis.from_url('redis://localhost:6379/1', socket_timeout=1)
+        ...     aioredis = AIORedis.from_url('redis://localhost:6379/1')
         ...     shower = AIORedlock(key='shower', masters={aioredis})
         ...     if await shower.acquire():
         ...         # Critical section - no other coroutine can enter while we hold the lock.
@@ -112,7 +112,7 @@ class AIORedlock(Scripts, AIOPrimitive):
     then you can specify your own timeout:
 
         >>> async def main():
-        ...     aioredis = AIORedis.from_url('redis://localhost:6379/1', socket_timeout=1)
+        ...     aioredis = AIORedis.from_url('redis://localhost:6379/1')
         ...     shower = AIORedlock(key='shower', masters={aioredis}, auto_release_time=15)
         ...     if await shower.acquire():
         ...         # Critical section - no other coroutine can enter while we hold the lock.
@@ -128,7 +128,7 @@ class AIORedlock(Scripts, AIOPrimitive):
     You can use an AIORedlock as a context manager:
 
         >>> async def main():
-        ...     aioredis = AIORedis.from_url('redis://localhost:6379/1', socket_timeout=1)
+        ...     aioredis = AIORedis.from_url('redis://localhost:6379/1')
         ...     shower = AIORedlock(key='shower', masters={aioredis}, auto_release_time=15)
         ...     async with shower:
         ...         print(f"shower is {'occupied' if await shower.locked() else 'available'}")

--- a/pottery/nextid.py
+++ b/pottery/nextid.py
@@ -116,7 +116,7 @@ class NextID(Scripts, Primitive):
     Clean up Redis for the doctest:
 
         >>> from redis import Redis
-        >>> redis = Redis(socket_timeout=1)
+        >>> redis = Redis()
         >>> redis.delete('nextid:tweet-ids') in {0, 1}
         True
 

--- a/pottery/redlock.py
+++ b/pottery/redlock.py
@@ -162,7 +162,7 @@ class Redlock(Scripts, Primitive):
     Usage:
 
         >>> from redis import Redis
-        >>> redis = Redis(socket_timeout=1)
+        >>> redis = Redis()
         >>> printer_lock = Redlock(key='printer', masters={redis})
         >>> bool(printer_lock.locked())
         False
@@ -368,7 +368,7 @@ class Redlock(Scripts, Primitive):
         necessary to acquire the lock.  Return True.
 
             >>> from redis import Redis
-            >>> redis = Redis(socket_timeout=1)
+            >>> redis = Redis()
             >>> printer_lock_1 = Redlock(key='printer', masters={redis})
             >>> printer_lock_1.acquire()
             True
@@ -451,7 +451,7 @@ class Redlock(Scripts, Primitive):
         If we don't currently hold the lock, then this method returns 0.
 
             >>> from redis import Redis
-            >>> redis = Redis(socket_timeout=1)
+            >>> redis = Redis()
             >>> printer_lock_1 = Redlock(key='printer', masters={redis})
             >>> printer_lock_1.locked()
             0
@@ -508,7 +508,7 @@ class Redlock(Scripts, Primitive):
         Usage:
 
             >>> from redis import Redis
-            >>> redis = Redis(socket_timeout=1)
+            >>> redis = Redis()
             >>> printer_lock = Redlock(key='printer', masters={redis})
             >>> printer_lock.acquire()
             True
@@ -560,7 +560,7 @@ class Redlock(Scripts, Primitive):
         Usage:
 
             >>> from redis import Redis
-            >>> redis = Redis(socket_timeout=1)
+            >>> redis = Redis()
             >>> printer_lock = Redlock(key='printer', masters={redis})
             >>> bool(printer_lock.locked())
             False
@@ -608,7 +608,7 @@ class Redlock(Scripts, Primitive):
         Usage:
 
             >>> from redis import Redis
-            >>> redis = Redis(socket_timeout=1)
+            >>> redis = Redis()
             >>> with Redlock(key='printer', masters={redis}) as printer_lock:
             ...     print('printer_lock is locked')
             ...     # Critical section - print stuff here.
@@ -657,7 +657,7 @@ class Redlock(Scripts, Primitive):
         Usage:
 
             >>> from redis import Redis
-            >>> redis = Redis(socket_timeout=1)
+            >>> redis = Redis()
             >>> with Redlock(key='printer', masters={redis}) as printer_lock:
             ...     print('printer_lock is locked')
             ...     # Critical section - print stuff here.

--- a/tests/test_redlock.py
+++ b/tests/test_redlock.py
@@ -224,7 +224,7 @@ class RedlockTests(TestCase):
                 ...  # pragma: no cover
 
     def test_repr(self):
-        assert repr(self.redlock) == "<Redlock key=redlock:printer>"
+        assert repr(self.redlock) == '<Redlock key=redlock:printer>'
 
     def test_slots(self):
         with self.assertRaises(AttributeError):


### PR DESCRIPTION
It's great to specify `socket_timeout` in production, but it distracts
in doctests.