### PR TITLE
fix: handle PYTHONOPTIMIZE=2 stripping docstrings (closes #702)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ from setuptools import setup
 
 __title__ = 'pottery'
 __version__ = '3.0.1'
-__description__ = __doc__.split(sep='\n\n', maxsplit=1)[0]
+__description__ = (__doc__ or '').split(sep='\n\n', maxsplit=1)[0]
 __url__ = 'https://github.com/brainix/pottery'
 __author__ = 'Rajiv Bakulesh Shah'
 __author_email__ = 'brainix@gmail.com'


### PR DESCRIPTION
## What
When `PYTHONOPTIMIZE=2` is set, Python strips all docstrings, causing `__doc__` to be `None`. The line `__description__ = __doc__.split(sep='\n\n', maxsplit=1)[0]` then raises `AttributeError: 'NoneType' object has no attribute 'split'`, breaking the import of pottery.

## Fix
Guard against `__doc__` being `None` by using `(__doc__ or '')` before calling `.split()`.

Closes #702