### PR TITLE
Use GitHub Copilot to upgrade GitHub Actions

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -27,9 +27,9 @@ jobs:
           - 6379:6379
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v7
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: ${{ matrix.python-version }}
         cache: 'pip'
@@ -49,6 +49,6 @@ jobs:
       run: |
         bandit --recursive pottery
     - name: Check for security vulnerabilities with Safety
-      uses: pyupio/safety-action@v1
+      uses: pyupio/safety-action@v1.0.1
       with:
         api-key: ${{ secrets.SAFETY_API_KEY }}

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -27,7 +27,7 @@ jobs:
           - 6379:6379
 
     steps:
-    - uses: actions/checkout@v7
+    - uses: actions/checkout@v6
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v6
       with:


### PR DESCRIPTION
This fixes this warning during CI:

```
Warning: Node.js 20 is deprecated. The following actions target Node.js
20 but are being forced to run on Node.js 24: actions/checkout@v4,
actions/setup-python@v5. For more information see:
https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/
```